### PR TITLE
Fix command execution for Windows -- npm-run instead of npx

### DIFF
--- a/packages/devcmd-cli/src/index.ts
+++ b/packages/devcmd-cli/src/index.ts
@@ -48,24 +48,14 @@ async function isDir(path: string): Promise<boolean> {
   }
 }
 
-function isWindows(): boolean {
-  return process.platform === "win32";
-}
-
-function withCmdOnWin(baseCmd: string): string {
-  return isWindows() ? `${baseCmd}.cmd` : baseCmd;
-}
-
 // Note: if launching a node subprocess for the resolution should turn out to be a problem,
 //   we could also use the npm module "resolve" to find the path ourselves (and e.g. require it in-process).
 //   See https://yarnpkg.com/package/resolve
 async function runInDevCmdsDir(dirPath: string) {
   const [, , ...args] = process.argv;
-  const argString = args.map((s) => `"${s}"`).join(",");
 
   // TODO: use spawn or so instead
-  // we're using `npx` to launch node so that it automatically augments the PATH with the relevant `node_modules/.bin` dir(s)
-  execFileSync(withCmdOnWin("npx"), ["node", "-e", `require('devcmd').devcmd(${argString})`], {
+  execFileSync("node", ["-e", `require('devcmd').devcmd(...process.argv.slice(1))`, ...args], {
     cwd: dirPath,
     stdio: "inherit",
   });

--- a/packages/devcmd/package.json
+++ b/packages/devcmd/package.json
@@ -19,8 +19,10 @@
     "/dist"
   ],
   "dependencies": {
+    "@types/npm-run": "^5.0.0",
     "chalk": "^3.0.0",
-    "devcmd-cli": "0.0.2"
+    "devcmd-cli": "0.0.2",
+    "npm-run": "^5.0.1"
   },
   "devDependencies": {
     "@types/node": "12",

--- a/packages/devcmd/src/devcmd.ts
+++ b/packages/devcmd/src/devcmd.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "child_process";
+import { spawnSync } from "npm-run";
 import { promises as fs } from "fs";
 import path from "path";
 
@@ -52,6 +52,14 @@ async function isFile(path: string): Promise<boolean> {
   }
 }
 
+function isWindows(): boolean {
+  return process.platform === "win32";
+}
+
+function withCmdOnWin(baseCmd: string): string {
+  return isWindows() ? `${baseCmd}.cmd` : baseCmd;
+}
+
 const scriptRunners = [
   { extension: "ts", launcher: "ts-node" },
   { extension: "js", launcher: "node" },
@@ -62,7 +70,8 @@ async function findAndRunScript(devCmdsDir: string, commandName: string, command
     const scriptFilepath = path.join(devCmdsDir, `${commandName}.${extension}`);
     if (await isFile(scriptFilepath)) {
       // TODO: use spawn or so instead
-      execFileSync("npx", [launcher, scriptFilepath, ...commandArgs], { stdio: "inherit" });
+      spawnSync(withCmdOnWin(launcher), [scriptFilepath, ...commandArgs], { stdio: "inherit" });
+
       return;
     }
   }


### PR DESCRIPTION
Use npm-run instead of npx to run dev_cmds because npx doesn't correctly escape arguments with quotes or spaces on Windows (and seems unmaintained, so no chance of a fix, making it unsuited for our usages).

See npm/npx#10 and npm/npx#43

Since `devcmd` now takes care of PATH augmentation, `devcmd-cli` can just execute `node` regularly and doesn't need to go through npx (this was probably already redundant before).