### PR TITLE
2 more exec function variants, some utils and nicer info output

### DIFF
--- a/dev_cmds/run-integration-tests.ts
+++ b/dev_cmds/run-integration-tests.ts
@@ -175,7 +175,7 @@ async function testSinglePackageJsonExample(tempImageName: string, devcmdCliInfo
       ],
     });
 
-    if (!stdout.trim().startsWith("Example command for single-package-json example")) {
+    if (!stdout.includes("Example command for single-package-json example")) {
       console.log(red("single-package-json didn't print expected output."));
       console.log(red("Actual stdout was:"));
       console.log(red(stdout));
@@ -238,7 +238,7 @@ async function testMultiplePackageJsonsExample(tempImageName: string, devcmdCliI
       ],
     });
 
-    if (!stdout.trim().startsWith("Example command for multiple-package-jsons example")) {
+    if (!stdout.includes("Example command for multiple-package-jsons example")) {
       console.log(red("multiple-package-jsons didn't print expected output."));
       console.log(red("Actual stdout was:"));
       console.log(red(stdout));

--- a/dev_cmds/run-integration-tests.ts
+++ b/dev_cmds/run-integration-tests.ts
@@ -164,7 +164,7 @@ async function testSinglePackageJsonExample(tempImageName: string, devcmdCliInfo
       ],
     });
 
-    const { stdout } = await execToString({
+    const { stdout, stderr } = await execToString({
       command: DOCKER_COMMAND,
       args: [
         "exec",
@@ -177,8 +177,10 @@ async function testSinglePackageJsonExample(tempImageName: string, devcmdCliInfo
 
     if (!stdout.trim().startsWith("Example command for single-package-json example")) {
       console.log(red("single-package-json didn't print expected output."));
-      console.log(red("Actual output was:"));
+      console.log(red("Actual stdout was:"));
       console.log(red(stdout));
+      console.log(red("Stderr was:"));
+      console.log(red(stderr));
 
       throw new Error("single-package-json didn't print expected output (see log above)");
     } else {
@@ -221,7 +223,7 @@ async function testMultiplePackageJsonsExample(tempImageName: string, devcmdCliI
       ],
     });
 
-    const { stdout } = await execToString({
+    const { stdout, stderr } = await execToString({
       command: DOCKER_COMMAND,
       args: [
         "exec",
@@ -238,8 +240,10 @@ async function testMultiplePackageJsonsExample(tempImageName: string, devcmdCliI
 
     if (!stdout.trim().startsWith("Example command for multiple-package-jsons example")) {
       console.log(red("multiple-package-jsons didn't print expected output."));
-      console.log(red("Actual output was:"));
+      console.log(red("Actual stdout was:"));
       console.log(red(stdout));
+      console.log(red("Stderr was:"));
+      console.log(red(stderr));
 
       throw new Error("multiple-package-jsons didn't print expected output (see log above)");
     } else {

--- a/examples/multiple-package-jsons/dev_cmds/example_cmd.ts
+++ b/examples/multiple-package-jsons/dev_cmds/example_cmd.ts
@@ -1,14 +1,14 @@
-import { exec, execParallel } from "devcmd";
+import { execPiped, execPipedParallel } from "devcmd";
 
 (async () => {
   console.log("Example command for multiple-package-jsons example");
 
-  await exec({
+  await execPiped({
     command: "node",
     args: ["-v"],
   });
 
-  await execParallel({
+  await execPipedParallel({
     nodeVersion: {
       command: "node",
       args: ["-v"],

--- a/examples/single-package-json/dev_cmds/example_cmd.ts
+++ b/examples/single-package-json/dev_cmds/example_cmd.ts
@@ -1,14 +1,14 @@
-import { exec, execParallel } from "devcmd";
+import { execPiped, execPipedParallel } from "devcmd";
 
 (async () => {
   console.log("Example command for single-package-json example");
 
-  await exec({
+  await execPiped({
     command: "node",
     args: ["-v"],
   });
 
-  await execParallel({
+  await execPipedParallel({
     nodeVersion: {
       command: "node",
       args: ["-v"],

--- a/packages/devcmd-cli/package.json
+++ b/packages/devcmd-cli/package.json
@@ -25,7 +25,7 @@
     "typescript": "^4.1.2"
   },
   "scripts": {
-    "clean": "rimraf ./dist",
+    "clean": "rimraf ./dist && rimraf *.tgz",
     "build": "yarn clean && tsc"
   }
 }

--- a/packages/devcmd/package.json
+++ b/packages/devcmd/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.1.2"
   },
   "scripts": {
-    "clean": "rimraf ./dist",
+    "clean": "rimraf ./dist && rimraf *.tgz",
     "build": "yarn clean && tsc",
     "start-verdaccio-container": "docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio"
   }

--- a/packages/devcmd/src/devcmd.ts
+++ b/packages/devcmd/src/devcmd.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from "fs";
-import { gray, bold, red } from "kleur/colors";
+import { gray, bold, red, reset } from "kleur/colors";
 import { spawnSync } from "npm-run";
 import path from "path";
+import { formatCommandArgs, formatCommandName } from "./utils/format_utils";
 import { withCmdOnWin } from "./utils/platform_utils";
 import { getDevcmdVersion } from "./utils/version_utils";
 
@@ -40,14 +41,11 @@ function assertArgsValid(args: string[]): args is string[] {
   return true;
 }
 
-function printScriptHeader(scriptName: string, scriptArgs: string[]) {
-  let argsString = "";
-  if (!!scriptArgs && scriptArgs.length > 0) {
-    argsString += gray(" with args [");
-    argsString += (scriptArgs || []).map((a) => gray('"') + a + gray('"')).join(",");
-    argsString += gray("]");
-  }
-  console.log(`${gray(": cmd")} ${scriptName}${argsString}`);
+function printScriptHeader(commandName: string, commandArgs: string[]) {
+  const commandString = formatCommandName(commandName, gray, reset);
+  const argsString =
+    !!commandArgs && commandArgs.length > 0 ? gray(" with args ") + formatCommandArgs(commandArgs, gray, reset) : "";
+  console.log(`${gray(": cmd")} ${commandString}${argsString}`);
 }
 
 function abort(message: string, exitCode: number = 1): never {

--- a/packages/devcmd/src/devcmd.ts
+++ b/packages/devcmd/src/devcmd.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "npm-run";
 import { promises as fs } from "fs";
 import path from "path";
+import { withCmdOnWin } from "./utils/platform_utils";
 
 const devCmdsDirName = "dev_cmds";
 
@@ -50,14 +51,6 @@ async function isFile(path: string): Promise<boolean> {
     if (error.code === "ENOENT") return false; // TODO double-check code and comparison value
     throw error;
   }
-}
-
-function isWindows(): boolean {
-  return process.platform === "win32";
-}
-
-function withCmdOnWin(baseCmd: string): string {
-  return isWindows() ? `${baseCmd}.cmd` : baseCmd;
 }
 
 const scriptRunners = [

--- a/packages/devcmd/src/index.ts
+++ b/packages/devcmd/src/index.ts
@@ -1,2 +1,3 @@
 export { devcmd } from "./devcmd";
 export { execInTty, execPiped, execPipedParallel, execToString, ProcessExecutor, ProcessInfo } from "./process";
+export { withCmdOnWin } from "./utils/platform_utils";

--- a/packages/devcmd/src/index.ts
+++ b/packages/devcmd/src/index.ts
@@ -1,2 +1,2 @@
 export { devcmd } from "./devcmd";
-export { exec, execInTty, execParallel, execToString, ProcessExecutor, ProcessInfo } from "./process";
+export { execInTty, execPiped, execPipedParallel, execToString, ProcessExecutor, ProcessInfo } from "./process";

--- a/packages/devcmd/src/index.ts
+++ b/packages/devcmd/src/index.ts
@@ -1,2 +1,2 @@
 export { devcmd } from "./devcmd";
-export { exec, execParallel, ProcessExecutor, ProcessInfo } from "./process";
+export { exec, execInTty, execParallel, execToString, ProcessExecutor, ProcessInfo } from "./process";

--- a/packages/devcmd/src/process/ProcessExecutor.ts
+++ b/packages/devcmd/src/process/ProcessExecutor.ts
@@ -17,8 +17,22 @@ export interface ConsoleLike {
   error(message?: any, ...optionalParams: any[]): void;
 }
 
+class SafeConsoleLike implements ConsoleLike {
+  constructor(private readonly consoleLike: ConsoleLike | undefined | null) {}
+
+  log(message?: any, ...optionalParams: any[]): void {
+    if (this.consoleLike) this.consoleLike.log(message, ...optionalParams);
+  }
+  error(message?: any, ...optionalParams: any[]): void {
+    if (this.consoleLike) this.consoleLike.error(message, ...optionalParams);
+  }
+}
+
 export class ProcessExecutor {
-  constructor(private readonly consoleLike: ConsoleLike) {
+  private readonly consoleLike: ConsoleLike;
+
+  constructor(consoleLike: ConsoleLike) {
+    this.consoleLike = new SafeConsoleLike(consoleLike);
     this.exec = this.exec.bind(this);
     this.execParallel = this.execParallel.bind(this);
   }

--- a/packages/devcmd/src/process/ProcessExecutor.ts
+++ b/packages/devcmd/src/process/ProcessExecutor.ts
@@ -107,6 +107,29 @@ export class ProcessExecutor {
 
     consoleError(kleur.gray(`Process '${processInfo.command}' exited successfully.\n`));
   }
+
+  async execInTty(processInfo: ProcessInfo): Promise<void> {
+    const options = processInfo.options ?? {};
+
+    const childProcess = spawn(processInfo.command, processInfo.args ?? [], {
+      cwd: options.cwd,
+      stdio: "inherit",
+      env: {
+        ...(options.env ?? process.env),
+      },
+    });
+
+    const code = await new Promise((resolve, reject) => {
+      childProcess.on("error", (err) => reject(err));
+      childProcess.on("exit", (code) => resolve(code));
+    });
+
+    if (code !== 0) {
+      const message = `Process '${processInfo.command}' exited with status code ${code}`;
+      this.consoleLike.error(kleur.red(message));
+      throw new Error(message);
+    }
+  }
 }
 
 type Result = { ok: true } | { err: unknown };

--- a/packages/devcmd/src/process/ProcessExecutor.ts
+++ b/packages/devcmd/src/process/ProcessExecutor.ts
@@ -33,29 +33,31 @@ export class ProcessExecutor {
 
   constructor(consoleLike: ConsoleLike) {
     this.consoleLike = new SafeConsoleLike(consoleLike);
-    this.exec = this.exec.bind(this);
-    this.execParallel = this.execParallel.bind(this);
+    this.execPiped = this.execPiped.bind(this);
+    this.execPipedParallel = this.execPipedParallel.bind(this);
   }
 
   /**
    * Executes a process and throws an exception if the exit code is non-zero.
    * Outputs (stdout/stderr) of the process are sent to our stdout/stderr.
    */
-  async exec(processInfo: ProcessInfo): Promise<void> {
-    await this.execInternal(processInfo, "");
+  async execPiped(processInfo: ProcessInfo): Promise<void> {
+    await this.execPipedInternal(processInfo, "");
   }
 
   /**
    * Executes multiple processes in parallel and throws an exception if the exit code is non-zero.
    * Outputs (stdout/stderr) of the processes are sent to our stdout/stderr.
    */
-  async execParallel(processEntries: { [id: string]: ProcessInfo } | { [id: number]: ProcessInfo }): Promise<void> {
+  async execPipedParallel(
+    processEntries: { [id: string]: ProcessInfo } | { [id: number]: ProcessInfo }
+  ): Promise<void> {
     this.consoleLike.error("Beginning parallel execution...");
     try {
       unwrapResults(
         await Promise.all([
           ...Object.entries(processEntries).map(([id, processInfo]) =>
-            wrapResult(() => this.execInternal(processInfo, kleur.cyan(`<${id}> `)))
+            wrapResult(() => this.execPipedInternal(processInfo, kleur.cyan(`<${id}> `)))
           ),
         ])
       );
@@ -64,7 +66,7 @@ export class ProcessExecutor {
     }
   }
 
-  private async execInternal(processInfo: ProcessInfo, logPrefix: string): Promise<void> {
+  private async execPipedInternal(processInfo: ProcessInfo, logPrefix: string): Promise<void> {
     const withPrefix = (line: string) => `${logPrefix}${line}`;
     const consoleLog = (line: string, ...params: any[]) => this.consoleLike.log(withPrefix(line), ...params);
     const consoleError = (line: string, ...params: any[]) => this.consoleLike.error(withPrefix(line), ...params);

--- a/packages/devcmd/src/process/index.ts
+++ b/packages/devcmd/src/process/index.ts
@@ -1,4 +1,4 @@
 import { ProcessExecutor } from "./ProcessExecutor";
 
-export const { exec, execInTty, execParallel, execToString } = new ProcessExecutor(console);
+export const { execInTty, execPiped, execPipedParallel, execToString } = new ProcessExecutor(console);
 export { ProcessExecutor, ProcessInfo } from "./ProcessExecutor";

--- a/packages/devcmd/src/process/index.ts
+++ b/packages/devcmd/src/process/index.ts
@@ -1,4 +1,4 @@
 import { ProcessExecutor } from "./ProcessExecutor";
 
-export const { exec, execParallel } = new ProcessExecutor(console);
+export const { exec, execInTty, execParallel, execToString } = new ProcessExecutor(console);
 export { ProcessExecutor, ProcessInfo } from "./ProcessExecutor";

--- a/packages/devcmd/src/process/process.test.ts
+++ b/packages/devcmd/src/process/process.test.ts
@@ -3,8 +3,12 @@ import { ConsoleLike } from "./ProcessExecutor";
 
 describe("ProcessExecutor", () => {
   describe("exec()", () => {
-    test("process that successfully exits works", async () => {
+    test("process that successfully exits works (with console)", async () => {
       await new ProcessExecutor(nullConsole).exec({ command: "node", args: ["--version"] });
+    });
+
+    test("process that successfully exits works (with no console)", async () => {
+      await new ProcessExecutor(null as any).exec({ command: "node", args: ["--version"] });
     });
 
     test("unknown executable throws", async () => {
@@ -21,8 +25,15 @@ describe("ProcessExecutor", () => {
   });
 
   describe("execParallel()", () => {
-    test("succeeding processes by name works", async () => {
+    test("succeeding processes by name works (with console)", async () => {
       await new ProcessExecutor(nullConsole).execParallel({
+        node: { command: "node", args: ["--version"] },
+        npm: { command: withCmdOnWin("npm"), args: ["--version"] },
+      });
+    });
+
+    test("succeeding processes by name works (with no console)", async () => {
+      await new ProcessExecutor(undefined as any).execParallel({
         node: { command: "node", args: ["--version"] },
         npm: { command: withCmdOnWin("npm"), args: ["--version"] },
       });

--- a/packages/devcmd/src/process/process.test.ts
+++ b/packages/devcmd/src/process/process.test.ts
@@ -91,6 +91,41 @@ describe("ProcessExecutor", () => {
       await expect(execPromise).rejects.toThrowError("exited with status code 2");
     });
   });
+
+  describe("execToString()", () => {
+    test("process that successfully exits works (with console)", async () => {
+      const { stdout, stderr } = await new ProcessExecutor(nullConsole).execToString({
+        command: "node",
+        args: ["--version"],
+      });
+      expect(stderr).toBe("");
+      expect(stdout).toMatch(/v\d+\.\d+\.\d+/);
+    });
+
+    test("process that successfully exits works (with no console)", async () => {
+      const { stdout, stderr } = await new ProcessExecutor(undefined as any).execToString({
+        command: "node",
+        args: ["--version"],
+      });
+      expect(stderr).toBe("");
+      expect(stdout).toMatch(/v\d+\.\d+\.\d+/);
+    });
+
+    test("unknown executable throws", async () => {
+      expect.assertions(1);
+      const execPromise = new ProcessExecutor(nullConsole).execToString({ command: "unknown_executable" });
+      await expect(execPromise).rejects.toThrowError("spawn unknown_executable ENOENT");
+    });
+
+    test("failing executable throws", async () => {
+      expect.assertions(1);
+      const execPromise = new ProcessExecutor(nullConsole).execToString({
+        command: "node",
+        args: ["-e", "process.exit(2)"],
+      });
+      await expect(execPromise).rejects.toThrowError("exited with status code 2");
+    });
+  });
 });
 
 const nullConsole: ConsoleLike = {

--- a/packages/devcmd/src/process/process.test.ts
+++ b/packages/devcmd/src/process/process.test.ts
@@ -66,6 +66,31 @@ describe("ProcessExecutor", () => {
       ).rejects.toThrowError();
     });
   });
+
+  describe("execInTty()", () => {
+    test("process that successfully exits works (with console)", async () => {
+      await new ProcessExecutor(nullConsole).execInTty({ command: "node", args: ["--version"] });
+    });
+
+    test("process that successfully exits works (with no console)", async () => {
+      await new ProcessExecutor(null as any).execInTty({ command: "node", args: ["--version"] });
+    });
+
+    test("unknown executable throws", async () => {
+      expect.assertions(1);
+      const execPromise = new ProcessExecutor(nullConsole).execInTty({ command: "unknown_executable" });
+      await expect(execPromise).rejects.toThrowError("spawn unknown_executable ENOENT");
+    });
+
+    test("failing executable throws", async () => {
+      expect.assertions(1);
+      const execPromise = new ProcessExecutor(nullConsole).execInTty({
+        command: "node",
+        args: ["-e", "process.exit(2)"],
+      });
+      await expect(execPromise).rejects.toThrowError("exited with status code 2");
+    });
+  });
 });
 
 const nullConsole: ConsoleLike = {

--- a/packages/devcmd/src/process/process.test.ts
+++ b/packages/devcmd/src/process/process.test.ts
@@ -2,71 +2,6 @@ import { ProcessExecutor } from ".";
 import { ConsoleLike } from "./ProcessExecutor";
 
 describe("ProcessExecutor", () => {
-  describe("exec()", () => {
-    test("process that successfully exits works (with console)", async () => {
-      await new ProcessExecutor(nullConsole).exec({ command: "node", args: ["--version"] });
-    });
-
-    test("process that successfully exits works (with no console)", async () => {
-      await new ProcessExecutor(null as any).exec({ command: "node", args: ["--version"] });
-    });
-
-    test("unknown executable throws", async () => {
-      expect.assertions(1);
-      const execPromise = new ProcessExecutor(nullConsole).exec({ command: "unknown_executable" });
-      await expect(execPromise).rejects.toThrowError("spawn unknown_executable ENOENT");
-    });
-
-    test("failing executable throws", async () => {
-      expect.assertions(1);
-      const execPromise = new ProcessExecutor(nullConsole).exec({ command: "node", args: ["-e", "process.exit(2)"] });
-      await expect(execPromise).rejects.toThrowError("exited with status code 2");
-    });
-  });
-
-  describe("execParallel()", () => {
-    test("succeeding processes by name works (with console)", async () => {
-      await new ProcessExecutor(nullConsole).execParallel({
-        node: { command: "node", args: ["--version"] },
-        npm: { command: withCmdOnWin("npm"), args: ["--version"] },
-      });
-    });
-
-    test("succeeding processes by name works (with no console)", async () => {
-      await new ProcessExecutor(undefined as any).execParallel({
-        node: { command: "node", args: ["--version"] },
-        npm: { command: withCmdOnWin("npm"), args: ["--version"] },
-      });
-    });
-
-    test("succeeding processes by index works", async () => {
-      await new ProcessExecutor(nullConsole).execParallel({
-        1: { command: "node", args: ["--version"] },
-        2: { command: withCmdOnWin("npm"), args: ["--version"] },
-      });
-    });
-
-    test("single failing process throws", async () => {
-      expect.assertions(1);
-      await expect(
-        new ProcessExecutor(nullConsole).execParallel({
-          node: { command: "node", args: ["-e", "process.exit(2)"] },
-          npm: { command: withCmdOnWin("npm"), args: ["--version"] },
-        })
-      ).rejects.toThrowError();
-    });
-
-    test("multiple failing process throws", async () => {
-      expect.assertions(1);
-      await expect(
-        new ProcessExecutor(nullConsole).execParallel({
-          node: { command: "node", args: ["-e", "process.exit(2)"] },
-          unknown_executable: { command: "unknown_executable" },
-        })
-      ).rejects.toThrowError();
-    });
-  });
-
   describe("execInTty()", () => {
     test("process that successfully exits works (with console)", async () => {
       await new ProcessExecutor(nullConsole).execInTty({ command: "node", args: ["--version"] });
@@ -89,6 +24,74 @@ describe("ProcessExecutor", () => {
         args: ["-e", "process.exit(2)"],
       });
       await expect(execPromise).rejects.toThrowError("exited with status code 2");
+    });
+  });
+
+  describe("execPiped()", () => {
+    test("process that successfully exits works (with console)", async () => {
+      await new ProcessExecutor(nullConsole).execPiped({ command: "node", args: ["--version"] });
+    });
+
+    test("process that successfully exits works (with no console)", async () => {
+      await new ProcessExecutor(null as any).execPiped({ command: "node", args: ["--version"] });
+    });
+
+    test("unknown executable throws", async () => {
+      expect.assertions(1);
+      const execPromise = new ProcessExecutor(nullConsole).execPiped({ command: "unknown_executable" });
+      await expect(execPromise).rejects.toThrowError("spawn unknown_executable ENOENT");
+    });
+
+    test("failing executable throws", async () => {
+      expect.assertions(1);
+      const execPromise = new ProcessExecutor(nullConsole).execPiped({
+        command: "node",
+        args: ["-e", "process.exit(2)"],
+      });
+      await expect(execPromise).rejects.toThrowError("exited with status code 2");
+    });
+  });
+
+  describe("execPipedParallel()", () => {
+    test("succeeding processes by name works (with console)", async () => {
+      await new ProcessExecutor(nullConsole).execPipedParallel({
+        node: { command: "node", args: ["--version"] },
+        npm: { command: withCmdOnWin("npm"), args: ["--version"] },
+      });
+    });
+
+    test("succeeding processes by name works (with no console)", async () => {
+      await new ProcessExecutor(undefined as any).execPipedParallel({
+        node: { command: "node", args: ["--version"] },
+        npm: { command: withCmdOnWin("npm"), args: ["--version"] },
+      });
+    });
+
+    test("succeeding processes by index works", async () => {
+      await new ProcessExecutor(nullConsole).execPipedParallel({
+        1: { command: "node", args: ["--version"] },
+        2: { command: withCmdOnWin("npm"), args: ["--version"] },
+      });
+    });
+
+    test("single failing process throws", async () => {
+      expect.assertions(1);
+      await expect(
+        new ProcessExecutor(nullConsole).execPipedParallel({
+          node: { command: "node", args: ["-e", "process.exit(2)"] },
+          npm: { command: withCmdOnWin("npm"), args: ["--version"] },
+        })
+      ).rejects.toThrowError();
+    });
+
+    test("multiple failing process throws", async () => {
+      expect.assertions(1);
+      await expect(
+        new ProcessExecutor(nullConsole).execPipedParallel({
+          node: { command: "node", args: ["-e", "process.exit(2)"] },
+          unknown_executable: { command: "unknown_executable" },
+        })
+      ).rejects.toThrowError();
     });
   });
 

--- a/packages/devcmd/src/utils/format_utils.ts
+++ b/packages/devcmd/src/utils/format_utils.ts
@@ -1,0 +1,15 @@
+export function formatCommandName(commandName: string, baseStyler: Styler, highlightStyler: Styler): string {
+  return quoted(commandName, baseStyler, highlightStyler);
+}
+
+export function formatCommandArgs(args: string[] | undefined, baseStyler: Styler, highlightStyler: Styler): string {
+  return !!args && args.length > 0
+    ? baseStyler("[") + args.map((a) => quoted(a, baseStyler, highlightStyler)).join(",") + baseStyler("]")
+    : "";
+}
+
+function quoted(s: string, quoteStyler: Styler, textStyler: Styler): string {
+  return quoteStyler('"') + textStyler(s) + quoteStyler('"');
+}
+
+export type Styler = (s: string) => string;

--- a/packages/devcmd/src/utils/platform_utils.ts
+++ b/packages/devcmd/src/utils/platform_utils.ts
@@ -1,0 +1,13 @@
+function isWindows(): boolean {
+  return process.platform === "win32";
+}
+
+/**
+ * Returns `${baseCmd}.cmd` in Windows, or just baseCmd otherwise.
+ *
+ * Many script-based external commands (e.g. bin scripts included with npm packages)
+ * are .cmd files on Windows but extensionless executable files on other platforms.
+ */
+export function withCmdOnWin(baseCmd: string): string {
+  return isWindows() ? `${baseCmd}.cmd` : baseCmd;
+}

--- a/packages/devcmd/src/utils/version_utils.ts
+++ b/packages/devcmd/src/utils/version_utils.ts
@@ -1,0 +1,4 @@
+export function getDevcmdVersion(): string {
+  const packageJson = require("../../package.json");
+  return packageJson["version"];
+}


### PR DESCRIPTION
* add an `execInTty` function and an `execToString` function for common use cases besides directly piping to the parent output
  * rename existing functions to `execPiped` and `execPipedParallel` to make the distinction clear
* add a `withCmdOnWin` function that appends the ".cmd" extension on Windows (used e.g. by the bin scripts of npm packages)
* improve formatting of info output (e.g. when a command starts or is finished)