### PR TITLE
Split devcmd's entry point for bin script (devcmd-cli)

### DIFF
--- a/packages/devcmd-cli/src/index.ts
+++ b/packages/devcmd-cli/src/index.ts
@@ -55,7 +55,7 @@ async function runInDevCmdsDir(dirPath: string) {
   const [, , ...args] = process.argv;
 
   // TODO: use spawn or so instead
-  execFileSync("node", ["-e", `require('devcmd').devcmd(...process.argv.slice(1))`, ...args], {
+  execFileSync("node", ["-e", `require('devcmd/from-cli').run(...process.argv.slice(1))`, ...args], {
     cwd: dirPath,
     stdio: "inherit",
   });

--- a/packages/devcmd/package.json
+++ b/packages/devcmd/package.json
@@ -9,10 +9,14 @@
   "homepage": "https://github.com/XITASO/devcmd#readme",
   "author": "XITASO GmbH",
   "license": "MIT",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./from-cli": "./dist/from-cli/index.js"
+  },
   "bin": {
-    "devcmd": "bin/devcmd.js"
+    "devcmd": "./bin/devcmd.js"
   },
   "files": [
     "/bin",

--- a/packages/devcmd/src/from-cli/index.ts
+++ b/packages/devcmd/src/from-cli/index.ts
@@ -2,13 +2,13 @@ import { promises as fs } from "fs";
 import { gray, bold, red, reset } from "kleur/colors";
 import { spawnSync } from "npm-run";
 import path from "path";
-import { formatCommandArgs, formatCommandName } from "./utils/format_utils";
-import { withCmdOnWin } from "./utils/platform_utils";
-import { getDevcmdVersion } from "./utils/version_utils";
+import { formatCommandArgs, formatCommandName } from "../utils/format_utils";
+import { withCmdOnWin } from "../utils/platform_utils";
+import { getDevcmdVersion } from "../utils/version_utils";
 
 const devCmdsDirName = "dev_cmds";
 
-export function devcmd(...args: string[]) {
+export function run(...args: string[]) {
   printDevcmdHeader();
   assertInDevCmdsDir();
   assertArgsValid(args);

--- a/packages/devcmd/src/index.ts
+++ b/packages/devcmd/src/index.ts
@@ -1,3 +1,2 @@
-export { devcmd } from "./devcmd";
 export { execInTty, execPiped, execPipedParallel, execToString, ProcessExecutor, ProcessInfo } from "./process";
 export { withCmdOnWin } from "./utils/platform_utils";


### PR DESCRIPTION
This change makes it clearer that the (new) `devcmd/from-cli` export is intended specifically as an entry point from the CLI invocation. Hopefully, this helps with reaching a stable interface exposed for `devcmd-cli`.

It also frees up the "devcmd" export of the default entry point, so that we can maybe use it for other convenience functions later.