### PR TITLE
Add a dev_cmd to bump the package versions

### DIFF
--- a/dev_cmds/build-all.ts
+++ b/dev_cmds/build-all.ts
@@ -1,6 +1,6 @@
 import { exec } from "devcmd";
 import { YARN_COMMAND } from "./utils/commands";
-import { repoRoot } from "./utils/directories";
+import { repoRoot } from "./utils/paths";
 import { runAsyncMain } from "./utils/run_utils";
 
 async function main() {

--- a/dev_cmds/bump-version.ts
+++ b/dev_cmds/bump-version.ts
@@ -1,0 +1,208 @@
+import { exec as execPiped } from "devcmd";
+import { blue, cyan, dim, green, yellow } from "kleur/colors";
+import fs from "fs-extra";
+import path from "path";
+import prompts from "prompts";
+import { YARN_COMMAND } from "./utils/commands";
+import {
+  devcmdCliPackageDir,
+  devcmdPackageDir,
+  multiplePackageJsonsExampleDir,
+  repoRoot,
+  singlePackageJsonExampleDir,
+} from "./utils/paths";
+import { runAsyncMain } from "./utils/run_utils";
+
+async function main(args: string[]) {
+  const packageInfo = await selectPackage();
+  console.log();
+
+  await packageInfo.f();
+
+  console.log();
+  console.log(yellow("You should commit these changes."));
+  console.log();
+}
+
+async function selectPackage(): Promise<PackageInfo> {
+  const response = await prompts(
+    {
+      type: "select",
+      name: "package",
+      message: "Choose package whose version to bump",
+      choices: packageInfos.map((pi) => ({ title: pi.package, value: pi })),
+    },
+    { onCancel: promptCanceled }
+  );
+  return response.package;
+}
+
+interface PackageInfo {
+  package: string;
+  f: () => Promise<void>;
+}
+
+const PACKAGE_JSON_FILENAME = "package.json";
+
+const devcmdPackageName = "devcmd";
+const devcmdCliPackageName = "devcmd-cli";
+const packageInfos: PackageInfo[] = [
+  { package: devcmdCliPackageName, f: bumpVersionDevcmdCli },
+  { package: devcmdPackageName, f: bumpVersionDevcmd },
+];
+
+async function bumpVersionDevcmd() {
+  const devcmdPackageJsonPath = path.resolve(devcmdPackageDir, PACKAGE_JSON_FILENAME);
+
+  const { newVersion } = await updatePackageJson(devcmdPackageJsonPath, devcmdPackageName, async (packageJson) => {
+    const oldVersion = packageJson["version"];
+    const { newVersion } = await getNewVersion(devcmdPackageName, oldVersion);
+    console.log();
+    printPackageJsonFieldUpdate(devcmdPackageJsonPath, ["version"], oldVersion, newVersion);
+    packageJson["version"] = newVersion;
+    return [packageJson, { newVersion }];
+  });
+
+  const newDependencyVersion = `^${newVersion}`;
+
+  const singlePJPackageJsonPath = path.resolve(singlePackageJsonExampleDir, PACKAGE_JSON_FILENAME);
+  await updatePackageJson(singlePJPackageJsonPath, "devcmd-examples_single-package-json", async (packageJson) => {
+    console.log();
+    printPackageJsonFieldUpdate(
+      singlePJPackageJsonPath,
+      ["devDependencies", devcmdPackageName],
+      packageJson["devDependencies"][devcmdPackageName],
+      newDependencyVersion
+    );
+    packageJson["devDependencies"][devcmdPackageName] = newDependencyVersion;
+    return packageJson;
+  });
+
+  const multiplePJsPackageJsonPath = path.resolve(multiplePackageJsonsExampleDir, "dev_cmds", PACKAGE_JSON_FILENAME);
+  await updatePackageJson(
+    multiplePJsPackageJsonPath,
+    "devcmd-examples_multiple-package-jsons_dev-cmds",
+    async (packageJson) => {
+      console.log();
+      printPackageJsonFieldUpdate(
+        multiplePJsPackageJsonPath,
+        ["devDependencies", devcmdPackageName],
+        packageJson["devDependencies"][devcmdPackageName],
+        newDependencyVersion
+      );
+      packageJson["devDependencies"][devcmdPackageName] = newDependencyVersion;
+      return packageJson;
+    }
+  );
+}
+
+async function bumpVersionDevcmdCli() {
+  const devcmdCliPackageJsonPath = path.resolve(devcmdCliPackageDir, PACKAGE_JSON_FILENAME);
+
+  const { newVersion } = await updatePackageJson(
+    devcmdCliPackageJsonPath,
+    devcmdCliPackageName,
+    async (packageJson) => {
+      const oldVersion = packageJson["version"];
+      const { newVersion } = await getNewVersion(devcmdCliPackageName, oldVersion);
+      console.log();
+      printPackageJsonFieldUpdate(devcmdCliPackageJsonPath, ["version"], oldVersion, newVersion);
+      packageJson["version"] = newVersion;
+      return [packageJson, { newVersion }];
+    }
+  );
+
+  const newDependencyVersion = `^${newVersion}`;
+  const devcmdPackageJsonPath = path.resolve(devcmdPackageDir, PACKAGE_JSON_FILENAME);
+  await updatePackageJson(devcmdPackageJsonPath, devcmdPackageName, async (packageJson) => {
+    console.log();
+    printPackageJsonFieldUpdate(
+      devcmdPackageJsonPath,
+      ["dependencies", devcmdCliPackageName],
+      packageJson["dependencies"][devcmdCliPackageName],
+      newDependencyVersion
+    );
+    packageJson["dependencies"][devcmdCliPackageName] = newDependencyVersion;
+    return packageJson;
+  });
+}
+
+function printPackageJsonFieldUpdate(
+  packageJsonPath: string,
+  propertyPath: string[],
+  oldValue: string,
+  newValue: string
+) {
+  const packageJsonRelativePath = path.relative(repoRoot, packageJsonPath);
+  const formattedPropertyPath = propertyPath.map((s) => ` > ${cyan(s)}`).join("");
+  console.log(
+    `Updating ${blue(packageJsonRelativePath)}${formattedPropertyPath}: ${green(dim(oldValue))} => ${green(newValue)}`
+  );
+}
+
+async function getNewVersion(packageName: string, oldVersion: string): Promise<{ newVersion: string }> {
+  console.log(`Package ${cyan(packageName)} is currently at version ${green(oldVersion)}`);
+  const versionParts = oldVersion.split(".");
+  const [major, minor, patch] = versionParts;
+  const newPatch = parseInt(patch) + 1;
+  const suggestedVersion = [major, minor, newPatch].join(".");
+
+  const response = await prompts(
+    {
+      type: "text",
+      name: "newVersion",
+      message: "Enter new version:",
+      initial: suggestedVersion,
+      validate: (userInput) =>
+        (typeof userInput === "string" && userInput.split(".").length === 3) ||
+        "Please enter a valid semver version string",
+    },
+    { onCancel: promptCanceled }
+  );
+  const newVersion: string = response.newVersion;
+  return { newVersion };
+}
+
+type PackageJson = { [prop: string]: any };
+
+async function updatePackageJson<R = undefined>(
+  packageJsonPath: string,
+  expectedPackageName: string,
+  updater: (old: PackageJson) => Promise<R extends undefined ? PackageJson : [PackageJson, R]>
+): Promise<R> {
+  const packageJson: PackageJson = await fs.readJson(packageJsonPath);
+  if (packageJson.name !== expectedPackageName) {
+    throw new Error(
+      `Expected package name "${expectedPackageName}" but found "${packageJson.name}" in file ${packageJsonPath}`
+    );
+  }
+
+  const updated = await updater(packageJson);
+  const [newPackageJson, result] = Array.isArray(updated) ? updated : [updated, undefined];
+
+  await fs.writeJson(packageJsonPath, newPackageJson);
+  await formatFile(packageJsonPath);
+
+  return result;
+}
+
+async function formatFile(absolutePath: string) {
+  await execPiped({
+    command: YARN_COMMAND,
+    args: ["prettier", "--write", absolutePath],
+    options: { cwd: repoRoot },
+  });
+}
+
+function getPackageJsonInfo(dir: string): { name: string; version: string } {
+  const packageJson = require(path.resolve(dir, "package.json"));
+  const { name, version } = packageJson;
+  return { name, version };
+}
+
+function promptCanceled() {
+  console.log(yellow("Aborting as requested."));
+  process.exit();
+}
+
+runAsyncMain(main);

--- a/dev_cmds/package.json
+++ b/dev_cmds/package.json
@@ -4,9 +4,11 @@
     "@tsconfig/node12": "^1.0.7",
     "@types/fs-extra": "^9.0.5",
     "@types/node": "14",
+    "@types/prompts": "^2.0.9",
     "devcmd": "^0.0.4",
     "fs-extra": "^9.0.1",
     "kleur": "^4.1.3",
+    "prompts": "^2.4.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
   }

--- a/dev_cmds/run-integration-tests.ts
+++ b/dev_cmds/run-integration-tests.ts
@@ -13,17 +13,19 @@ import path from "path";
 import fs from "fs-extra";
 import { red, green, inverse } from "kleur/colors";
 import { DEVCMD_COMMAND, DOCKER_COMMAND, NPM_COMMAND } from "./utils/commands";
-import { repoRoot } from "./utils/directories";
+import {
+  devcmdCliPackageDir,
+  devcmdPackageDir,
+  multiplePackageJsonsExampleDir,
+  repoRoot,
+  singlePackageJsonExampleDir,
+} from "./utils/paths";
 import { runAsyncMain } from "./utils/run_utils";
 import { execToString } from "./utils/exec_process";
 
 const VERDACCIO_CONTAINER_NAME = "devcmd_verdaccio";
 const VERDACCIO_STORAGE_VOLUME_NAME = "devcmd_verdaccio_storage";
 const LOCAL_REGISTRY_URL = "http://0.0.0.0:4873";
-
-const packagesDir = path.resolve(repoRoot, "packages");
-const devcmdCliPackageDir = path.resolve(packagesDir, "devcmd-cli");
-const devcmdPackageDir = path.resolve(packagesDir, "devcmd");
 
 const verdaccioConfigDir = path.resolve(repoRoot, "verdaccio");
 const dockerMountDir = path.resolve(repoRoot, "docker-mount");
@@ -145,7 +147,7 @@ async function testSinglePackageJsonExample(tempImageName: string, devcmdCliInfo
 
     await exec({
       command: DOCKER_COMMAND,
-      args: ["cp", path.resolve(repoRoot, "examples/single-package-json"), `${containerName}:/tmp/devcmd_test`],
+      args: ["cp", singlePackageJsonExampleDir, `${containerName}:/tmp/devcmd_test`],
     });
 
     await exec({
@@ -202,7 +204,7 @@ async function testMultiplePackageJsonsExample(tempImageName: string, devcmdCliI
 
     await exec({
       command: DOCKER_COMMAND,
-      args: ["cp", path.resolve(repoRoot, "examples/multiple-package-jsons"), `${containerName}:/tmp/devcmd_test`],
+      args: ["cp", multiplePackageJsonsExampleDir, `${containerName}:/tmp/devcmd_test`],
     });
 
     await exec({

--- a/dev_cmds/test-all.ts
+++ b/dev_cmds/test-all.ts
@@ -1,6 +1,6 @@
 import { exec } from "devcmd";
 import { YARN_COMMAND } from "./utils/commands";
-import { repoRoot } from "./utils/directories";
+import { repoRoot } from "./utils/paths";
 import { runAsyncMain } from "./utils/run_utils";
 
 async function main() {

--- a/dev_cmds/utils/commands.ts
+++ b/dev_cmds/utils/commands.ts
@@ -8,5 +8,6 @@ function withCmdOnWin(baseCmd: string): string {
 
 export const DEVCMD_COMMAND = withCmdOnWin("devcmd");
 export const DOCKER_COMMAND = "docker";
+export const GIT_COMMAND = "git";
 export const NPM_COMMAND = withCmdOnWin("npm");
 export const YARN_COMMAND = withCmdOnWin("yarn");

--- a/dev_cmds/utils/directories.ts
+++ b/dev_cmds/utils/directories.ts
@@ -1,5 +1,0 @@
-import { resolve } from "path";
-
-const repoRoot = resolve(__dirname, "..", "..");
-
-export { repoRoot };

--- a/dev_cmds/utils/paths.ts
+++ b/dev_cmds/utils/paths.ts
@@ -1,0 +1,13 @@
+import { resolve } from "path";
+
+const repoRoot = resolve(__dirname, "..", "..");
+
+const packagesDir = resolve(repoRoot, "packages");
+const devcmdCliPackageDir = resolve(packagesDir, "devcmd-cli");
+const devcmdPackageDir = resolve(packagesDir, "devcmd");
+
+const examplesDir = resolve(repoRoot, "examples");
+const singlePackageJsonExampleDir = resolve(examplesDir, "single-package-json");
+const multiplePackageJsonsExampleDir = resolve(examplesDir, "multiple-package-jsons");
+
+export { devcmdCliPackageDir, devcmdPackageDir, multiplePackageJsonsExampleDir, repoRoot, singlePackageJsonExampleDir };

--- a/dev_cmds/utils/run_utils.ts
+++ b/dev_cmds/utils/run_utils.ts
@@ -3,6 +3,7 @@ function abort(message: string, exitCode: number = 1): never {
   process.exit(exitCode);
 }
 
-export function runAsyncMain(main: () => Promise<void>): void {
-  main().catch((reason) => abort(reason));
+export function runAsyncMain(main: (args: string[]) => Promise<void>): void {
+  const [, , ...args] = process.argv;
+  main(args || []).catch((reason) => abort(reason));
 }

--- a/dev_cmds/yarn.lock
+++ b/dev_cmds/yarn.lock
@@ -26,6 +26,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/prompts@^2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.0.9.tgz#19f419310eaa224a520476b19d4183f6a2b3bd8f"
+  integrity sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==
+  dependencies:
+    "@types/node" "*"
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
@@ -100,6 +107,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+kleur@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
 kleur@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.3.tgz#8d262a56d79a137ee1b706e967c0b08a7fef4f4c"
@@ -141,6 +153,14 @@ npm-which@^3.0.1:
     npm-path "^2.0.2"
     which "^1.2.10"
 
+prompts@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.0.tgz#4aa5de0723a231d1ee9121c40fdf663df73f61d7"
+  integrity sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==
+  dependencies:
+    kleur "^3.0.3"
+    sisteransi "^1.0.5"
+
 protochain@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/protochain/-/protochain-1.0.5.tgz#991c407e99de264aadf8f81504b5e7faf7bfa260"
@@ -152,6 +172,11 @@ serializerr@^1.0.3:
   integrity sha1-EtTFqhw/+49tHcXzlaqUVVacP5E=
   dependencies:
     protochain "^1.0.5"
+
+sisteransi@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
 source-map-support@^0.5.17:
   version "0.5.19"


### PR DESCRIPTION
* Fixes #10 
* Add an interactive command `bump-version` that
  * prompts the user which of the two packages to version-bump
  * suggests a new version string with updated "patch" version, and asks the user to confirm or provide a version string
  * updates the package's version
  * updates the dependencies in the monorepo
  * optionally commits and tags the changed files