### PR TITLE
#21 fail runner when executed script fails

### DIFF
--- a/packages/devcmd/src/from-cli/index.ts
+++ b/packages/devcmd/src/from-cli/index.ts
@@ -83,7 +83,8 @@ async function findAndRunScript(devCmdsDir: string, commandName: string, command
     const scriptFilepath = path.join(devCmdsDir, `${commandName}.${extension}`);
     if (await isFile(scriptFilepath)) {
       // TODO: use spawn or so instead
-      spawnSync(withCmdOnWin(launcher), [scriptFilepath, ...commandArgs], { stdio: "inherit" });
+      const { status } = spawnSync(withCmdOnWin(launcher), [scriptFilepath, ...commandArgs], { stdio: "inherit" });
+      if (status !== null && status != 0) throw new Error(`Process failed with exit code ${status}`);
 
       return;
     }


### PR DESCRIPTION
This change seems to fix the problem described in #21.

`yarn devcmd test && echo This should not be shown if the command fails` works correctly when executed in bash 
(but not when executed in cmd.exe, which seems to be an issue with yarn.cmd)