### PR TITLE
Adding devcontainer config and development setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT="16-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,5 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/typescript-node/.devcontainer/base.Dockerfile
 
 # [Choice] Node.js version: 16, 14, 12
-ARG VARIANT="16-buster"
+ARG VARIANT="12-buster"
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
-
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment if you want to install an additional version of node using nvm
-# ARG EXTRA_NODE_VERSION=10
-# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
-
-# [Optional] Uncomment if you want to install more global node packages
-# RUN su node -c "npm install -g <your-package-list -here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 12, 14, 16
+		"args": { 
+			"VARIANT": "16"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,30 +1,24 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/typescript-node
 {
-	"name": "Node.js & TypeScript",
-	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 12, 14, 16
-		"args": { 
-			"VARIANT": "16"
-		}
-	},
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint"
-	],
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
-
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node"
+    "name": "Node.js & TypeScript",
+    "build": {
+        "dockerfile": "Dockerfile",
+        // Update 'VARIANT' to pick a Node version: 12, 14, 16
+        "args": {
+            "VARIANT": "12"
+        }
+    },
+    // Set *default* container specific settings.json values on container create.
+    "settings": {},
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "dbaeumer.vscode-eslint"
+    ],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "yarn install",
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 {
-    "name": "Node.js & TypeScript",
-    "build": {
-        "dockerfile": "Dockerfile",
-        "args": {
-            "VARIANT": "12"
-        }
-    },
-    "settings": {},
-    "remoteUser": "node"
+  "name": "Node.js & TypeScript",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "VARIANT": "12"
+    }
+  },
+  "settings": {},
+  "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,24 +1,11 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/typescript-node
 {
     "name": "Node.js & TypeScript",
     "build": {
         "dockerfile": "Dockerfile",
-        // Update 'VARIANT' to pick a Node version: 12, 14, 16
         "args": {
             "VARIANT": "12"
         }
     },
-    // Set *default* container specific settings.json values on container create.
     "settings": {},
-    // Add the IDs of extensions you want installed when the container is created.
-    "extensions": [
-        "dbaeumer.vscode-eslint"
-    ],
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // "forwardPorts": [],
-    // Use 'postCreateCommand' to run commands after the container is created.
-    // "postCreateCommand": "yarn install",
-    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "node"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 tsconfig.tsbuildinfo
 yarn-error.log
 dist/
+dev/
 
 # locally packed npm packages
 *.tgz

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ $ devcmd build
 It is recommended to use the [Remote-Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for Visual Studio Code for this. Once the extension is installed,
 click `Reopen in Container` within the popup in the bottom right or open the command palette and run the command `Remote-Containers: Reopen in Container`.
 
-Since both the `devcmd` and the `devcmd-cli` packages use local installations within __node_modules__ folders,
+Since both the `devcmd` and the `devcmd-cli` packages use local installations within **node_modules** folders,
 developing and especially testing devcmd locally can be challenging. In order to setup a local development
-environment, you can use the devcmd task `setup-dev`, which intializes a `dev`-folder, that contains the required `devcmd`-package as a yarn symlink. 
+environment, you can use the devcmd task `setup-dev`, which intializes a `dev`-folder, that contains the required `devcmd`-package as a yarn symlink.
 
 ```sh
 $ yarn devcmd setup-dev

--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ $ devcmd build
 
 ## Setting up a local development setup
 
+It is recommended to use the [Remote-Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for Visual Studio Code for this. Once the extension is installed,
+click `Reopen in Container` within the popup in the bottom right or open the command palette and run the command `Remote-Containers: Reopen in Container`.
+
 Since both the `devcmd` and the `devcmd-cli` packages use local installations within __node_modules__ folders,
 developing and especially testing devcmd locally can be challenging. In order to setup a local development
-environment, you can use the script `setup-dev`, which intializes a `dev`-folder, that contains the required `devcmd`-package
-as a yarn symlink. It is recommended to use the Remote-Containers extension for Visual Studio Code for this.
+environment, you can use the devcmd task `setup-dev`, which intializes a `dev`-folder, that contains the required `devcmd`-package as a yarn symlink. 
 
 ```sh
 $ yarn devcmd setup-dev
@@ -135,7 +137,7 @@ $ cd dev
 /dev $ npx devcmd [PARAMS]
 ```
 
-To properly cleanup the folder and the symlinks, use the devcmd `clean-dev`.
+To properly cleanup the folder and the symlinks, use the devcmd task `clean-dev`.
 
 ```sh
 $ yarn devcmd clean-dev

--- a/README.md
+++ b/README.md
@@ -97,3 +97,48 @@ Going back to the example "build" command from above, you can now run it from th
 ```sh
 $ devcmd build
 ```
+
+## Setting up a local development setup
+
+Since both the `devcmd` and the `devcmd-cli` packages use local installations within __node_modules__ folders,
+developing and especially testing devcmd locally can be challenging. In order to setup a local development
+environment, you can use the script `setup-dev`, which intializes a `dev`-folder, that contains the required `devcmd`-package
+as a yarn symlink. It is recommended to use the Remote-Containers extension for Visual Studio Code for this.
+
+```sh
+$ yarn devcmd setup-dev
+# - or -
+$ npx devcmd setup-dev
+```
+
+You can now change the `devcmd` and the `devcmd-cli` packages. In order to test your changes, build the packages and run
+devcmd in the generated dev folder.
+
+```sh
+# Build all packages
+$ yarn devcmd build-all
+# - or -
+$ npx devcmd build-all
+
+# You can also build a package seperately
+$ yarn workspace <package> build
+
+# Run devcmd in the dev environment using the utility script in the package.json
+$ yarn dev [PARAMS]
+# - or -
+$ npm run dev [PARAMS]
+
+# Alternatively you can run devcmd from within the dev folder
+$ cd dev
+/dev $ yarn devcmd [PARAMS]
+# - or -
+/dev $ npx devcmd [PARAMS]
+```
+
+To properly cleanup the folder and the symlinks, use the devcmd `clean-dev`.
+
+```sh
+$ yarn devcmd clean-dev
+# - or -
+$ npx devcmd clean-dev
+```

--- a/dev_cmds/clean-dev.ts
+++ b/dev_cmds/clean-dev.ts
@@ -1,11 +1,11 @@
 import { execPiped, runAsyncMain } from "devcmd";
 import { YARN_COMMAND } from "./utils/commands";
-import { devcmdPackageDir, devPath } from "./utils/paths";
+import { devcmdPackageDir, devDir } from "./utils/paths";
 import fs from "fs-extra";
 
 async function main() {
-  if (!(await fs.pathExists(devPath))) {
-    throw new Error("No development folder found!\n");
+  if (!(await fs.pathExists(devDir))) {
+    throw new Error("No development folder found!");
   }
 
   try {
@@ -13,11 +13,11 @@ async function main() {
       command: YARN_COMMAND,
       args: ["unlink", "devcmd"],
       options: {
-        cwd: devPath,
+        cwd: devDir,
       },
     });
   } catch {
-    process.stdout.write("Could not unlink devcmd from the development folder!\n");
+    console.warn("Could not unlink devcmd from the development folder!");
   }
 
   try {
@@ -29,13 +29,13 @@ async function main() {
       },
     });
   } catch {
-    process.stdout.write("Could not unlink the devcmd package!\n");
+    console.warn("Could not unlink the devcmd package!");
   }
 
   try {
-    await fs.remove(devPath);
+    await fs.remove(devDir);
   } catch {
-    process.stdout.write("Could not remove the devlopment folder!\n");
+    console.warn("Could not remove the devlopment folder!");
   }
 }
 

--- a/dev_cmds/clean-dev.ts
+++ b/dev_cmds/clean-dev.ts
@@ -4,10 +4,8 @@ import { devcmdPackageDir, devPath } from "./utils/paths";
 import fs from "fs-extra";
 
 async function main() {
-
-  if(!await fs.pathExists(devPath)) {
-    process.stderr.write('No development folder found!\n')
-    process.exit(1)
+  if (!(await fs.pathExists(devPath))) {
+    throw new Error("No development folder found!\n");
   }
 
   try {
@@ -18,7 +16,9 @@ async function main() {
         cwd: devPath,
       },
     });
-  } catch {}
+  } catch {
+    process.stdout.write("Could not unlink devcmd from the development folder!\n");
+  }
 
   try {
     await execPiped({
@@ -28,13 +28,15 @@ async function main() {
         cwd: devcmdPackageDir,
       },
     });
-  } catch {}
+  } catch {
+    process.stdout.write("Could not unlink the devcmd package!\n");
+  }
 
   try {
-    await fs.remove(
-      devPath
-    );
-  } catch {}
+    await fs.remove(devPath);
+  } catch {
+    process.stdout.write("Could not remove the devlopment folder!\n");
+  }
 }
 
 runAsyncMain(main);

--- a/dev_cmds/clean-dev.ts
+++ b/dev_cmds/clean-dev.ts
@@ -1,0 +1,40 @@
+import { execPiped, runAsyncMain } from "devcmd";
+import { YARN_COMMAND } from "./utils/commands";
+import { devcmdPackageDir, devPath } from "./utils/paths";
+import fs from "fs-extra";
+
+async function main() {
+
+  if(!await fs.pathExists(devPath)) {
+    process.stderr.write('No development folder found!\n')
+    process.exit(1)
+  }
+
+  try {
+    await execPiped({
+      command: YARN_COMMAND,
+      args: ["unlink", "devcmd"],
+      options: {
+        cwd: devPath,
+      },
+    });
+  } catch {}
+
+  try {
+    await execPiped({
+      command: YARN_COMMAND,
+      args: ["unlink"],
+      options: {
+        cwd: devcmdPackageDir,
+      },
+    });
+  } catch {}
+
+  try {
+    await fs.remove(
+      devPath
+    );
+  } catch {}
+}
+
+runAsyncMain(main);

--- a/dev_cmds/setup-dev.ts
+++ b/dev_cmds/setup-dev.ts
@@ -4,22 +4,16 @@ import { devcmdPackageDir, devPath, singlePackageJsonExampleDir } from "./utils/
 import fs from "fs-extra";
 
 async function main() {
-
-  if(await fs.pathExists(devPath)) {
-    process.stderr.write('A development folder already exists!\n')
-    process.exit(1)
+  if (await fs.pathExists(devPath)) {
+    throw new Error("A development folder already exists!\n");
   }
 
-  await fs.copy(
-    singlePackageJsonExampleDir,
-    devPath,
-    {
-      // Only copy those files, for which the filter evaluates to true
-      filter: (src) => !src.includes('node_modules')
-    }
-  );
-
   try {
+    await fs.copy(singlePackageJsonExampleDir, devPath, {
+      // Only copy those files, for which the filter evaluates to true
+      filter: (src) => !src.includes("node_modules"),
+    });
+
     await execPiped({
       command: YARN_COMMAND,
       args: ["link"],
@@ -27,7 +21,7 @@ async function main() {
         cwd: devcmdPackageDir,
       },
     });
-  
+
     await execPiped({
       command: YARN_COMMAND,
       args: ["link", "devcmd"],
@@ -35,7 +29,7 @@ async function main() {
         cwd: devPath,
       },
     });
-  
+
     await execPiped({
       command: YARN_COMMAND,
       args: ["install"],
@@ -44,8 +38,7 @@ async function main() {
       },
     });
   } catch {
-    process.stderr.write("Could not setup the dev environment!");
-    process.exit(1);
+    throw new Error("Could not setup the dev environment!");
   }
 }
 

--- a/dev_cmds/setup-dev.ts
+++ b/dev_cmds/setup-dev.ts
@@ -1,0 +1,52 @@
+import { execPiped, runAsyncMain } from "devcmd";
+import { YARN_COMMAND } from "./utils/commands";
+import { devcmdPackageDir, devPath, singlePackageJsonExampleDir } from "./utils/paths";
+import fs from "fs-extra";
+
+async function main() {
+
+  if(await fs.pathExists(devPath)) {
+    process.stderr.write('A development folder already exists!\n')
+    process.exit(1)
+  }
+
+  await fs.copy(
+    singlePackageJsonExampleDir,
+    devPath,
+    {
+      // Only copy those files, for which the filter evaluates to true
+      filter: (src) => !src.includes('node_modules')
+    }
+  );
+
+  try {
+    await execPiped({
+      command: YARN_COMMAND,
+      args: ["link"],
+      options: {
+        cwd: devcmdPackageDir,
+      },
+    });
+  
+    await execPiped({
+      command: YARN_COMMAND,
+      args: ["link", "devcmd"],
+      options: {
+        cwd: devPath,
+      },
+    });
+  
+    await execPiped({
+      command: YARN_COMMAND,
+      args: ["install"],
+      options: {
+        cwd: devPath,
+      },
+    });
+  } catch {
+    process.stderr.write("Could not setup the dev environment!");
+    process.exit(1);
+  }
+}
+
+runAsyncMain(main);

--- a/dev_cmds/setup-dev.ts
+++ b/dev_cmds/setup-dev.ts
@@ -1,15 +1,15 @@
 import { execPiped, runAsyncMain } from "devcmd";
 import { YARN_COMMAND } from "./utils/commands";
-import { devcmdPackageDir, devPath, singlePackageJsonExampleDir } from "./utils/paths";
+import { devcmdPackageDir, devDir, singlePackageJsonExampleDir } from "./utils/paths";
 import fs from "fs-extra";
 
 async function main() {
-  if (await fs.pathExists(devPath)) {
-    throw new Error("A development folder already exists!\n");
+  if (await fs.pathExists(devDir)) {
+    throw new Error(`A development folder already exists at ${devDir}!`);
   }
 
   try {
-    await fs.copy(singlePackageJsonExampleDir, devPath, {
+    await fs.copy(singlePackageJsonExampleDir, devDir, {
       // Only copy those files, for which the filter evaluates to true
       filter: (src) => !src.includes("node_modules"),
     });
@@ -26,7 +26,7 @@ async function main() {
       command: YARN_COMMAND,
       args: ["link", "devcmd"],
       options: {
-        cwd: devPath,
+        cwd: devDir,
       },
     });
 
@@ -34,11 +34,11 @@ async function main() {
       command: YARN_COMMAND,
       args: ["install"],
       options: {
-        cwd: devPath,
+        cwd: devDir,
       },
     });
-  } catch {
-    throw new Error("Could not setup the dev environment!");
+  } catch (e) {
+    throw new Error(`Could not setup the dev environment! ${e}`);
   }
 }
 

--- a/dev_cmds/utils/paths.ts
+++ b/dev_cmds/utils/paths.ts
@@ -1,4 +1,4 @@
-import path, { resolve } from "path";
+import { join, resolve } from "path";
 
 const repoRoot = resolve(__dirname, "..", "..");
 
@@ -6,7 +6,7 @@ const packagesDir = resolve(repoRoot, "packages");
 const devcmdCliPackageDir = resolve(packagesDir, "devcmd-cli");
 const devcmdPackageDir = resolve(packagesDir, "devcmd");
 
-const devPath = path.join(repoRoot, "dev");
+const devDir = join(repoRoot, "dev");
 const examplesDir = resolve(repoRoot, "examples");
 const singlePackageJsonExampleDir = resolve(examplesDir, "single-package-json");
 const multiplePackageJsonsExampleDir = resolve(examplesDir, "multiple-package-jsons");
@@ -17,7 +17,7 @@ const dockerMountDir = resolve(repoRoot, "docker-mount");
 export {
   devcmdCliPackageDir,
   devcmdPackageDir,
-  devPath,
+  devDir,
   dockerMountDir,
   examplesDir,
   multiplePackageJsonsExampleDir,

--- a/dev_cmds/utils/paths.ts
+++ b/dev_cmds/utils/paths.ts
@@ -6,7 +6,7 @@ const packagesDir = resolve(repoRoot, "packages");
 const devcmdCliPackageDir = resolve(packagesDir, "devcmd-cli");
 const devcmdPackageDir = resolve(packagesDir, "devcmd");
 
-const devPath = path.join(repoRoot, 'dev');
+const devPath = path.join(repoRoot, "dev");
 const examplesDir = resolve(repoRoot, "examples");
 const singlePackageJsonExampleDir = resolve(examplesDir, "single-package-json");
 const multiplePackageJsonsExampleDir = resolve(examplesDir, "multiple-package-jsons");

--- a/dev_cmds/utils/paths.ts
+++ b/dev_cmds/utils/paths.ts
@@ -1,4 +1,4 @@
-import { resolve } from "path";
+import path, { resolve } from "path";
 
 const repoRoot = resolve(__dirname, "..", "..");
 
@@ -6,6 +6,7 @@ const packagesDir = resolve(repoRoot, "packages");
 const devcmdCliPackageDir = resolve(packagesDir, "devcmd-cli");
 const devcmdPackageDir = resolve(packagesDir, "devcmd");
 
+const devPath = path.join(repoRoot, 'dev');
 const examplesDir = resolve(repoRoot, "examples");
 const singlePackageJsonExampleDir = resolve(examplesDir, "single-package-json");
 const multiplePackageJsonsExampleDir = resolve(examplesDir, "multiple-package-jsons");
@@ -16,7 +17,9 @@ const dockerMountDir = resolve(repoRoot, "docker-mount");
 export {
   devcmdCliPackageDir,
   devcmdPackageDir,
+  devPath,
   dockerMountDir,
+  examplesDir,
   multiplePackageJsonsExampleDir,
   repoRoot,
   singlePackageJsonExampleDir,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "devcmd": "cd dev_cmds && yarn devcmd",
+    "dev": "cd dev && yarn devcmd",
     "postinstall": "cd dev_cmds && yarn"
   }
 }

--- a/packages/devcmd-cli/src/index.ts
+++ b/packages/devcmd-cli/src/index.ts
@@ -49,13 +49,11 @@ async function isDir(path: string): Promise<boolean> {
 }
 
 async function startProcess(command: string, args: Array<string>, dirPath: string): Promise<number> {
-  const spawnOptions: SpawnOptions = {
-    stdio: 'inherit',
-    cwd: dirPath
-  };
-
-  const processPromise: Promise<number> = new Promise<number>((resolve, reject) => {
-    const processInstance: ChildProcess = spawn(command, args, spawnOptions);
+  return new Promise<number>((resolve, reject) => {
+    const processInstance: ChildProcess = spawn(command, args, {
+      stdio: "inherit",
+      cwd: dirPath,
+    });
 
     processInstance.on("error", (err: Error): void => {
       // The 'error' event gets emitted when the process couldn't be spawned, killed or communicated with
@@ -67,12 +65,6 @@ async function startProcess(command: string, args: Array<string>, dirPath: strin
       else reject(code);
     });
   });
-
-  return processPromise;
-}
-
-function isError(err: any): err is Error {
-  return err instanceof Error;
 }
 
 // Note: if launching a node subprocess for the resolution should turn out to be a problem,
@@ -82,8 +74,8 @@ async function runInDevCmdsDir(dirPath: string): Promise<void> {
   const [, , ...args] = process.argv;
 
   try {
-    await startProcess('node', ["-e", `require('devcmd/from-cli').run(...process.argv.slice(1))`, ...args], dirPath);
+    await startProcess("node", ["-e", `require('devcmd/from-cli').run(...process.argv.slice(1))`, ...args], dirPath);
   } catch (err) {
-    isError(err) ? abort(err.stack ?? err.message) : process.exit(1);
+    err instanceof Error ? abort(err.stack ?? err.message) : process.exit(1);
   }
 }

--- a/packages/devcmd-cli/src/index.ts
+++ b/packages/devcmd-cli/src/index.ts
@@ -58,7 +58,8 @@ async function startProcess(command: string, args: Array<string>, dirPath: strin
     const processInstance: ChildProcess = spawn(command, args, spawnOptions);
 
     processInstance.on("error", (err: Error): void => {
-      throw err;
+      // The 'error' event gets emitted when the process couldn't be spawned, killed or communicated with
+      reject(err);
     });
 
     processInstance.on("close", (code: number): void => {
@@ -83,6 +84,6 @@ async function runInDevCmdsDir(dirPath: string): Promise<void> {
   try {
     await startProcess('node', ["-e", `require('devcmd/from-cli').run(...process.argv.slice(1))`, ...args], dirPath);
   } catch (err) {
-    isError(err) ? abort(err.message) : process.exit(1);
+    isError(err) ? abort(err.stack ?? err.message) : process.exit(1);
   }
 }

--- a/packages/devcmd-cli/src/index.ts
+++ b/packages/devcmd-cli/src/index.ts
@@ -58,7 +58,7 @@ async function startProcess(command: string, args: Array<string>, dirPath: strin
     const processInstance: ChildProcess = spawn(command, args, spawnOptions);
 
     processInstance.on("error", (err: Error): void => {
-      throw new Error(err.message);
+      throw err;
     });
 
     processInstance.on("close", (code: number): void => {


### PR DESCRIPTION
One part of this PR deals with setting up a devcontainer configuration for VSCode. Using this allows you to safely develop devcmd without the possibility of eventually breaking the local / global node_modules. However using this is completely optional, all the changes also work in the local setup.

The other part of the PR adds 2 dev commands, one for setting up and one for cleaning up a local dev setup. After copying one of the examples (single-package-json) into the root of the repostiory the devcmd package is symlinked into copied example. 
After the symlink is complete, you can develop the devcmd and devcmd-cli packages and test your changes with ease by rebuilding the packages and running devcmd in the copied "dev"-folder, which then uses the new devcmd version because of the symlink. 
The cleanup-devcmd removes the symlink and deletes the dev folder.

To read more about the new devcmds check the changes in the README.md 