### PR TITLE
devcmd/lint: Adding lint devcmd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: yarn install --frozen-lockfile
-      - run: yarn prettier --check .
+      - run: yarn devcmd lint

--- a/dev_cmds/lint.ts
+++ b/dev_cmds/lint.ts
@@ -1,0 +1,15 @@
+import { execPiped, runAsyncMain } from "devcmd";
+import { YARN_COMMAND } from "./utils/commands";
+import { repoRoot } from "./utils/paths";
+
+async function main() {
+  await execPiped({
+    command: YARN_COMMAND,
+    args: ["prettier", "--check", "."],
+    options: {
+      cwd: repoRoot,
+    },
+  });
+}
+
+runAsyncMain(main);


### PR DESCRIPTION
This small PR adds a 'lint' devcmd that wraps the command `yarn prettier --check .` 

A failing lint causes the process to exit with status code 1, which allows us to also use the new devcmd in the github actions pipeline.

![image](https://user-images.githubusercontent.com/25712873/127011954-8b8e65ac-4415-404a-9dc7-1c4137e068e6.png)
