### PR TITLE
Adjust fs error checking to silence newer TS errors

### DIFF
--- a/dev_cmds/utils/fs-utils.ts
+++ b/dev_cmds/utils/fs-utils.ts
@@ -5,12 +5,12 @@ export async function isFile(path: string): Promise<boolean> {
     const info = await fs.stat(path);
     return info.isFile();
   } catch (error) {
-    if (isNoSuchFileOrDirError(error)) return false;
+    // error code as per https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_common_system_errors
+    if (isNodeError(error) && error.code === "ENOENT") return false;
     throw error;
   }
 }
 
-function isNoSuchFileOrDirError(error: unknown): error is Error {
-  // error code as per https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_common_system_errors
-  return error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT";
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error;
 }

--- a/dev_cmds/utils/fs-utils.ts
+++ b/dev_cmds/utils/fs-utils.ts
@@ -5,7 +5,12 @@ export async function isFile(path: string): Promise<boolean> {
     const info = await fs.stat(path);
     return info.isFile();
   } catch (error) {
-    if (error.code === "ENOENT") return false; // TODO double-check code and comparison value
+    if (isNoSuchFileOrDirError(error)) return false;
     throw error;
   }
+}
+
+function isNoSuchFileOrDirError(error: unknown): error is Error {
+  // error code as per https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_common_system_errors
+  return error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT";
 }

--- a/packages/devcmd-cli/src/index.ts
+++ b/packages/devcmd-cli/src/index.ts
@@ -43,9 +43,14 @@ async function isDir(path: string): Promise<boolean> {
     const info = await fs.stat(path);
     return info.isDirectory();
   } catch (error) {
-    if (error.code === "ENOENT") return false; // TODO double-check code and comparison value
+    if (isNoSuchFileOrDirError(error)) return false;
     throw error;
   }
+}
+
+function isNoSuchFileOrDirError(error: unknown): error is Error {
+  // error code as per https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_common_system_errors
+  return error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT";
 }
 
 async function startProcess(command: string, args: Array<string>, dirPath: string): Promise<number> {

--- a/packages/devcmd-cli/src/index.ts
+++ b/packages/devcmd-cli/src/index.ts
@@ -43,14 +43,14 @@ async function isDir(path: string): Promise<boolean> {
     const info = await fs.stat(path);
     return info.isDirectory();
   } catch (error) {
-    if (isNoSuchFileOrDirError(error)) return false;
+    // error code as per https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_common_system_errors
+    if (isNodeError(error) && error.code === "ENOENT") return false;
     throw error;
   }
 }
 
-function isNoSuchFileOrDirError(error: unknown): error is Error {
-  // error code as per https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_common_system_errors
-  return error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT";
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error;
 }
 
 async function startProcess(command: string, args: Array<string>, dirPath: string): Promise<number> {

--- a/packages/devcmd/src/from-cli/index.ts
+++ b/packages/devcmd/src/from-cli/index.ts
@@ -88,14 +88,14 @@ async function isFile(path: string): Promise<boolean> {
     const info = await fs.stat(path);
     return info.isFile();
   } catch (error) {
-    if (isNoSuchFileOrDirError(error)) return false;
+    // error code as per https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_common_system_errors
+    if (isNodeError(error) && error.code === "ENOENT") return false;
     throw error;
   }
 }
 
-function isNoSuchFileOrDirError(error: unknown): error is Error {
-  // error code as per https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_common_system_errors
-  return error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT";
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error;
 }
 
 const scriptRunners = [

--- a/packages/devcmd/src/from-cli/index.ts
+++ b/packages/devcmd/src/from-cli/index.ts
@@ -83,24 +83,19 @@ function abort(message: string, exitCode: number = 1): never {
   process.exit(exitCode);
 }
 
-async function isDir(path: string): Promise<boolean> {
-  try {
-    const info = await fs.stat(path);
-    return info.isDirectory();
-  } catch (error) {
-    if (error.code === "ENOENT") return false; // TODO double-check code and comparison value
-    throw error;
-  }
-}
-
 async function isFile(path: string): Promise<boolean> {
   try {
     const info = await fs.stat(path);
     return info.isFile();
   } catch (error) {
-    if (error.code === "ENOENT") return false; // TODO double-check code and comparison value
+    if (isNoSuchFileOrDirError(error)) return false;
     throw error;
   }
+}
+
+function isNoSuchFileOrDirError(error: unknown): error is Error {
+  // error code as per https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_common_system_errors
+  return error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT";
 }
 
 const scriptRunners = [


### PR DESCRIPTION
Newer TS complained about our previous unchecked usage of the `code` field in Node's error objects.
This updated code squelches those errors, checks more explicitly, and works even if a non-Node Error object should somehow get into the `isNoSuchFileOrDirError` function (`error.code` will then yield `undefined` and the triple-equals will be false)

@do-see @schierla @lieberlois @lenaxus it would be great if you could shortly look over this :)