### PR TITLE
Add option "nonZeroExitCodeHandling" to make exec* methods not throw on non-zero exit codes

### DIFF
--- a/packages/devcmd/src/index.ts
+++ b/packages/devcmd/src/index.ts
@@ -1,3 +1,12 @@
-export { execInTty, execPiped, execPipedParallel, execToString, ProcessExecutor, ProcessInfo } from "./process";
+export {
+  execInTty,
+  execPiped,
+  execPipedParallel,
+  execToString,
+  ProcessExecutor,
+  ProcessInfo,
+  NodeExitInfo,
+  NonZeroExitCodeHandling,
+} from "./process";
 export { withCmdOnWin } from "./utils/platform_utils";
 export { runAsyncMain } from "./utils/run_utils";

--- a/packages/devcmd/src/process/ProcessExecutor.ts
+++ b/packages/devcmd/src/process/ProcessExecutor.ts
@@ -4,12 +4,15 @@ import { createInterface } from "readline";
 import { gray, red, reset, dim, bold, cyan, $ as kleur$ } from "kleur/colors";
 import { formatCommandArgs, formatCommandName, Styler } from "../utils/format_utils";
 
+export type NonZeroExitCodeHandling = "printErrorAndThrow" | "printNoticeAndReturn";
+
 export interface ProcessInfo {
   command: string;
   args?: string[];
   options?: {
     cwd?: string;
     env?: NodeJS.ProcessEnv;
+    nonZeroExitCodeHandling?: NonZeroExitCodeHandling;
   };
 }
 

--- a/packages/devcmd/src/process/ProcessExecutor.ts
+++ b/packages/devcmd/src/process/ProcessExecutor.ts
@@ -151,8 +151,7 @@ export class ProcessExecutor {
     ]);
 
     if (code !== 0) {
-      const commandName = formatProcessCommand(processInfo, identity, bold);
-      const message = `Process ${commandName} exited with status code ${code}`;
+      const message = formatNonZeroExitCodeMessage(processInfo, code);
       consoleError(red(message));
       throw new Error(message);
     }
@@ -175,8 +174,7 @@ export class ProcessExecutor {
     const code = await childProcessCompletion(childProcess);
 
     if (code !== 0) {
-      const commandName = formatProcessCommand(processInfo, identity, bold);
-      const message = `Process ${commandName} exited with status code ${code}`;
+      const message = formatNonZeroExitCodeMessage(processInfo, code);
       this.printError(message);
       throw new Error(message);
     }
@@ -212,9 +210,10 @@ export class ProcessExecutor {
     ]);
 
     if (exitCode !== 0) {
+      const nonZeroExitCodeMessage = formatNonZeroExitCodeMessage(processInfo, exitCode);
       const message =
-        `Process '${processInfo.command}' exited with status code ${exitCode}\n\n` +
-        `STDOUT WAS:\n${childStdout}\n\n` +
+        `${nonZeroExitCodeMessage}\n\n` + //
+        `STDOUT WAS:\n${childStdout}\n\n` + //
         `STDERR WAS:\n${childStderr}\n\n`;
 
       switch (nonZeroExitCodeHandling) {
@@ -300,6 +299,11 @@ function formatProcessCommand(
   highlightStyler: Styler = noticeHighlightStyled
 ): string {
   return formatCommandName(processInfo.command, baseStyler, highlightStyler);
+}
+
+function formatNonZeroExitCodeMessage(processInfo: ProcessInfo, code: number | null) {
+  const commandName = formatProcessCommand(processInfo, identity, bold);
+  return `Process ${commandName} exited with status code ${code}`;
 }
 
 function formatProcessInvocation(

--- a/packages/devcmd/src/process/index.ts
+++ b/packages/devcmd/src/process/index.ts
@@ -51,4 +51,4 @@ export const execPipedParallel = DefaultProcessExecutor.execPipedParallel;
 export const execInTty = DefaultProcessExecutor.execInTty;
 export const execToString = DefaultProcessExecutor.execToString;
 
-export { ProcessExecutor, ProcessInfo } from "./ProcessExecutor";
+export { NodeExitInfo, NonZeroExitCodeHandling, ProcessExecutor, ProcessInfo } from "./ProcessExecutor";

--- a/packages/devcmd/src/process/process.test.ts
+++ b/packages/devcmd/src/process/process.test.ts
@@ -33,7 +33,7 @@ describe("ProcessExecutor", () => {
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
         expect(capturingConsole.errorLines).toHaveLength(2);
         expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
         );
       });
     });
@@ -60,7 +60,7 @@ describe("ProcessExecutor", () => {
         expect(result.exitCode).toBe(2);
         expect(capturingConsole.errorLines).toHaveLength(2);
         expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
         );
       });
     });
@@ -93,7 +93,7 @@ describe("ProcessExecutor", () => {
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
         expect(capturingConsole.errorLines).toHaveLength(2);
         expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
         );
       });
     });
@@ -122,7 +122,7 @@ describe("ProcessExecutor", () => {
         expect(capturingConsole.logLines[0].message).toBe("still works");
         expect(capturingConsole.errorLines).toHaveLength(2);
         expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
         );
       });
     });
@@ -294,7 +294,7 @@ describe("ProcessExecutor", () => {
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
         expect(capturingConsole.errorLines).toHaveLength(2);
         expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
         );
       });
     });
@@ -322,7 +322,7 @@ describe("ProcessExecutor", () => {
         expect(result.stdout).toBe("still works\n");
         expect(capturingConsole.errorLines).toHaveLength(2);
         expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
         );
       });
     });

--- a/packages/devcmd/src/process/process.test.ts
+++ b/packages/devcmd/src/process/process.test.ts
@@ -3,6 +3,8 @@ import { isString } from "../utils/type_utils";
 import { ProcessExecutor } from ".";
 import { ConsoleLike } from "./ProcessExecutor";
 
+const ansiFormat = `(?:\\x1b\\[\\d+m)`;
+
 describe("ProcessExecutor", () => {
   describe("execInTty()", () => {
     test("process that successfully exits works (with console)", async () => {
@@ -162,7 +164,9 @@ describe("ProcessExecutor", () => {
         const execPromise = execToString({ command: "node", args: ["-e", "process.exit(2)"] });
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
         expect(capturingConsole.errorLines).toHaveLength(2);
-        expect(capturingConsole.errorLines[1].message).toMatch(/Process 'node' exited with status code 2/);
+        expect(capturingConsole.errorLines[1].message).toMatch(
+          new RegExp(`^${ansiFormat}Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+        );
       });
     });
 
@@ -189,7 +193,9 @@ describe("ProcessExecutor", () => {
         expect(result.stderr).toHaveLength(0);
         expect(result.stdout).toBe("still works\n");
         expect(capturingConsole.errorLines).toHaveLength(2);
-        expect(capturingConsole.errorLines[1].message).toMatch(/Process 'node' exited with status code 2/);
+        expect(capturingConsole.errorLines[1].message).toMatch(
+          new RegExp(`^${ansiFormat}Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+        );
       });
     });
 

--- a/packages/devcmd/src/utils/type_utils.ts
+++ b/packages/devcmd/src/utils/type_utils.ts
@@ -1,0 +1,3 @@
+export function isString(x: any): x is string {
+  return typeof x === "string";
+}


### PR DESCRIPTION
As discussed in #47, it's sometimes inconvenient to have DevCmd always treat non-zero exit codes as errors (i.e. the exec* methods throwing in this case). Some command-line tools use the exit code to communication information, so callers may want to just receive the exit code and treat it themselves.

This PR adds this optional behavior to all exec* methods, including unit tests.

Still to-do:
- [x] update documentation
- [x] fix unit test assertions to work in a non-tty environment
- [x] ~integration tests~ -- update: I think the unit tests cover this functionality very well, so we don't need any additional integrations tests for this for now

@Brunni, feel free to peruse and give feedback, or even try out this variant for yourself :)