### PR TITLE
Add support for specifying the script name exactly (i.e. including its extension)

### DIFF
--- a/dev_cmds/integration-tests/single-package-json-example.ts
+++ b/dev_cmds/integration-tests/single-package-json-example.ts
@@ -39,7 +39,6 @@ export function createSinglePackageJsonExampleTestGroup(): TestGroup {
   };
 
   const runExampleCmd: TestFunction = async (containerName: string) => {
-    const exampleCmdCommandLine = `npx devcmd example_cmd`;
     const { stdout, stderr } = await execToString({
       command: DOCKER_COMMAND,
       args: [
@@ -47,7 +46,32 @@ export function createSinglePackageJsonExampleTestGroup(): TestGroup {
         containerName,
         "sh",
         "-c",
-        ["cd /tmp/devcmd_test/single-package-json", exampleCmdCommandLine].join(" && "),
+        ["cd /tmp/devcmd_test/single-package-json", `npx devcmd example_cmd`].join(" && "),
+      ],
+    });
+
+    if (!stdout.includes("Example command for single-package-json example")) {
+      console.log(red("example_cmd didn't print expected output."));
+      console.log(red("Actual stdout was:"));
+      console.log(red(stdout));
+      console.log(red("Stderr was:"));
+      console.log(red(stderr));
+
+      return "fail";
+    } else {
+      return "success";
+    }
+  };
+
+  const runExampleCmdWithExtension: TestFunction = async (containerName: string) => {
+    const { stdout, stderr } = await execToString({
+      command: DOCKER_COMMAND,
+      args: [
+        "exec",
+        containerName,
+        "sh",
+        "-c",
+        ["cd /tmp/devcmd_test/single-package-json", `npx devcmd example_cmd.ts`].join(" && "),
       ],
     });
 
@@ -65,8 +89,6 @@ export function createSinglePackageJsonExampleTestGroup(): TestGroup {
   };
 
   const runFailsWithErrorCmd: TestFunction = async (containerName: string) => {
-    const exampleCmdCommandLine = `npx devcmd fails_with_error`;
-
     try {
       await execToString({
         command: DOCKER_COMMAND,
@@ -75,7 +97,7 @@ export function createSinglePackageJsonExampleTestGroup(): TestGroup {
           containerName,
           "sh",
           "-c",
-          ["cd /tmp/devcmd_test/single-package-json", exampleCmdCommandLine].join(" && "),
+          ["cd /tmp/devcmd_test/single-package-json", `npx devcmd fails_with_error`].join(" && "),
         ],
       });
 
@@ -95,10 +117,41 @@ export function createSinglePackageJsonExampleTestGroup(): TestGroup {
     return "fail";
   };
 
+  const runMissingCmd: TestFunction = async (containerName: string) => {
+    try {
+      await execToString({
+        command: DOCKER_COMMAND,
+        args: [
+          "exec",
+          containerName,
+          "sh",
+          "-c",
+          ["cd /tmp/devcmd_test/single-package-json", `npx devcmd missing_command`].join(" && "),
+        ],
+      });
+
+      console.log(red("Failure: Command completed successfully but should have errored."));
+    } catch (e) {
+      if (e instanceof Error && e.message.includes("No script file found for command 'missing_command'.")) {
+        return "success";
+      }
+
+      console.log(red("Failure: Test error didn't contain expected message."));
+      console.log(red(`  typeof: ${typeof e}, instanceof Error? ${e instanceof Error}`));
+      console.log(red("  Message:"));
+      console.log((e instanceof Error && e.message) || "(not an Error)");
+      console.log(red("  (End of message)"));
+    }
+
+    return "fail";
+  };
+
   const testCases = [
     { name: "Setup", fn: setup },
-    { name: "Run example_cmd", fn: runExampleCmd },
-    { name: "Run fails_with_error", fn: runFailsWithErrorCmd },
+    { name: "Running example_cmd works", fn: runExampleCmd },
+    { name: "Running example_cmd.ts (with extension) works", fn: runExampleCmdWithExtension },
+    { name: "Running fails_with_error exits with error", fn: runFailsWithErrorCmd },
+    { name: "Running a missing command exits with error", fn: runMissingCmd },
   ];
   return { name: "single-package-json", testCases };
 }


### PR DESCRIPTION
I noticed that it's sometimes useful to pass the command script file's name directly to DevCmd including the file extension.

This PR adds this capability for supported file extensions (otherwise we wouldn't know how to run the script).
If the scriptname ends with a supported extension and matches a file, this is preferred over all other candidates.

As always, @schierla, @do-see, @corux, @lieberlois, if any of you have time to look over this, I'd appreciate any review or feedback :)