### PR TITLE
Add option "suppressNotices" to prevent exec* methods from printing "starting" and "exited" notices

### DIFF
--- a/packages/devcmd/src/process/ProcessExecutor.ts
+++ b/packages/devcmd/src/process/ProcessExecutor.ts
@@ -25,17 +25,18 @@ export interface ProcessInfoOptions {
   /** Specifies how to handle a non-zero exit code. Default is `"printErrorAndThrow"`. */
   nonZeroExitCodeHandling?: NonZeroExitCodeHandling;
   /** If true, DevCmd does not print notices about starting and finishing process
-   *  execution. Default is false.*/
+   *  execution. Default is false. */
   suppressNotices?: boolean;
 }
 
 export interface ExecPipedParallelOptions {
   /** If true, DevCmd does not print notices about starting and finishing process
-   *  execution. In this case, this option is applied to all ProcessInfos
-   *  that are passed if it is true.
+   *  execution.
    *  If false (default), the notices for beginning and ending the parallel
-   *  execution are printed, but for the individual processes the respective
-   *  ProcessInfo's options are applied. */
+   *  execution are printed.
+   *  Individual ProcessInfo items can specify their own `suppressNotices` option,
+   *  which is preferred if present. In any ProcessInfo where the option is absent,
+   *  this value is applied as a fallback. */
   suppressNotices?: boolean;
 }
 
@@ -171,7 +172,7 @@ export class ProcessExecutor {
     let processEntries = Object.entries(processMapOrList);
     if (suppressNotices) {
       processEntries = processEntries.map(([k, processInfo]) => {
-        const newProcessInfo = { ...processInfo, options: { ...processInfo.options, suppressNotices } };
+        const newProcessInfo = { ...processInfo, options: { suppressNotices, ...processInfo.options } };
         return [k, newProcessInfo];
       });
     }

--- a/packages/devcmd/src/process/ProcessExecutor.ts
+++ b/packages/devcmd/src/process/ProcessExecutor.ts
@@ -22,8 +22,21 @@ export interface ProcessInfoOptions {
    * If specified, caller's environment is not automatically included, so caller
    * needs to do this if desired. */
   env?: NodeJS.ProcessEnv;
-  /** Specifies how to handle a non-zero exit code. */
+  /** Specifies how to handle a non-zero exit code. Default is `"printErrorAndThrow"`. */
   nonZeroExitCodeHandling?: NonZeroExitCodeHandling;
+  /** If true, DevCmd does not print notices about starting and finishing process
+   *  execution. Default is false.*/
+  suppressNotices?: boolean;
+}
+
+export interface ExecPipedParallelOptions {
+  /** If true, DevCmd does not print notices about starting and finishing process
+   *  execution. In this case, this option is applied to all ProcessInfos
+   *  that are passed if it is true.
+   *  If false (default), the notices for beginning and ending the parallel
+   *  execution are printed, but for the individual processes the respective
+   *  ProcessInfo's options are applied. */
+  suppressNotices?: boolean;
 }
 
 /** Information describing how to execute a process. */
@@ -53,11 +66,11 @@ export interface ConsoleLike {
  */
 export class ProcessExecutor {
   private readonly consoleLike: ConsoleLike;
-  private readonly logger: Logger;
+  private readonly logger: StylingLogger;
 
   constructor(consoleLike: ConsoleLike) {
     this.consoleLike = new SafeConsoleLike(consoleLike);
-    this.logger = new Logger(this.consoleLike.error.bind(this.consoleLike));
+    this.logger = new StylingLogger(this.consoleLike.error.bind(this.consoleLike));
     this.execInTty = this.execInTty.bind(this);
     this.execPiped = this.execPiped.bind(this);
     this.execPipedParallel = this.execPipedParallel.bind(this);
@@ -118,7 +131,8 @@ export class ProcessExecutor {
    * status info, once all processes have exited
    */
   async execPipedParallel<T extends { [id: string]: ProcessInfo }>(
-    processMap: T
+    processMap: T,
+    options?: ExecPipedParallelOptions
   ): Promise<{ [id in keyof T]: NodeExitInfo }>;
 
   /**
@@ -144,14 +158,25 @@ export class ProcessExecutor {
    * @returns A promise resolving to a list of exit status infos, one for each process in
    * the same order as `processList`, once all processes have exited
    */
-  async execPipedParallel(processList: ProcessInfo[]): Promise<NodeExitInfo[]>;
+  async execPipedParallel(processList: ProcessInfo[], options?: ExecPipedParallelOptions): Promise<NodeExitInfo[]>;
 
   /** Implementation for the two overload signatures above. */
   async execPipedParallel(
-    processMapOrList: ProcessInfo[] | { [id: string]: ProcessInfo }
+    processMapOrList: ProcessInfo[] | { [id: string]: ProcessInfo },
+    options?: ExecPipedParallelOptions
   ): Promise<NodeExitInfo[] | { [id: string]: NodeExitInfo }> {
-    const processEntries = Object.entries(processMapOrList);
-    this.logger.notice(`Beginning parallel execution of ${processEntries.length} processes...`);
+    const suppressNotices = !!options?.suppressNotices;
+    const logger = this.logger.withSuppression(suppressNotices);
+
+    let processEntries = Object.entries(processMapOrList);
+    if (suppressNotices) {
+      processEntries = processEntries.map(([k, processInfo]) => {
+        const newProcessInfo = { ...processInfo, options: { ...processInfo.options, suppressNotices } };
+        return [k, newProcessInfo];
+      });
+    }
+
+    logger.notice(`Beginning parallel execution of ${processEntries.length} processes...`);
     let results: NodeExitInfo[];
     try {
       results = unwrapResults(
@@ -162,7 +187,7 @@ export class ProcessExecutor {
         ])
       );
     } finally {
-      this.logger.notice("Finished parallel execution.");
+      logger.notice("Finished parallel execution.");
     }
 
     if (Array.isArray(processMapOrList)) return results;
@@ -171,11 +196,11 @@ export class ProcessExecutor {
   }
 
   private async execPipedInternal(processInfo: ProcessInfo, logPrefix: string): Promise<NodeExitInfo> {
+    const options = this.normalizeOptions(processInfo.options);
     const consoleLike = new PrefixingConsoleLike(this.consoleLike, logPrefix);
-    const logger = new Logger(consoleLike.error);
+    const logger = new StylingLogger(consoleLike.error).withSuppression(options.suppressNotices);
 
     logger.notice(`Starting process: ${formatProcessInvocation(processInfo)}`);
-    const options = this.normalizeOptions(processInfo.options);
 
     const childProcess = spawn(processInfo.command, processInfo.args ?? [], {
       cwd: options.cwd,
@@ -225,8 +250,9 @@ export class ProcessExecutor {
    * @returns A promise resolving to an object with exit status info once the process exits
    */
   async execInTty(processInfo: ProcessInfo): Promise<NodeExitInfo> {
-    this.logger.notice(`Starting process: ${formatProcessInvocation(processInfo)} attached to TTY`);
     const options = this.normalizeOptions(processInfo.options);
+    const logger = this.logger.withSuppression(options.suppressNotices);
+    logger.notice(`Starting process: ${formatProcessInvocation(processInfo)} attached to TTY`);
 
     const childProcess = spawn(processInfo.command, processInfo.args ?? [], {
       cwd: options.cwd,
@@ -236,8 +262,12 @@ export class ProcessExecutor {
 
     const exitInfo = await childProcessCompletion(childProcess);
 
-    this.handleExitInfo(exitInfo, processInfo, options.nonZeroExitCodeHandling, () =>
-      formatNonZeroExitCodeMessage(processInfo, exitInfo.exitCode)
+    this.handleExitInfo(
+      exitInfo,
+      processInfo,
+      options.nonZeroExitCodeHandling,
+      () => formatNonZeroExitCodeMessage(processInfo, exitInfo.exitCode),
+      logger
     );
 
     return exitInfo;
@@ -264,8 +294,9 @@ export class ProcessExecutor {
    * process's exit status info.
    */
   async execToString(processInfo: ProcessInfo): Promise<{ stdout: string; stderr: string } & NodeExitInfo> {
-    this.logger.notice(`Starting process: ${formatProcessInvocation(processInfo)} and capturing output`);
     const options = this.normalizeOptions(processInfo.options);
+    const logger = this.logger.withSuppression(options.suppressNotices);
+    logger.notice(`Starting process: ${formatProcessInvocation(processInfo)} and capturing output`);
 
     let childStdout: string = "";
     let childStderr: string = "";
@@ -287,10 +318,16 @@ export class ProcessExecutor {
       }),
     ]);
 
-    this.handleExitInfo(exitInfo, processInfo, options.nonZeroExitCodeHandling, () => {
-      const nonZeroExitCodeMessage = formatNonZeroExitCodeMessage(processInfo, exitInfo.exitCode);
-      return `${nonZeroExitCodeMessage}\n\nSTDOUT WAS:\n${childStdout}\n\nSTDERR WAS:\n${childStderr}\n\n`;
-    });
+    this.handleExitInfo(
+      exitInfo,
+      processInfo,
+      options.nonZeroExitCodeHandling,
+      () => {
+        const nonZeroExitCodeMessage = formatNonZeroExitCodeMessage(processInfo, exitInfo.exitCode);
+        return `${nonZeroExitCodeMessage}\n\nSTDOUT WAS:\n${childStdout}\n\nSTDERR WAS:\n${childStderr}\n\n`;
+      },
+      logger
+    );
 
     return { stdout: childStdout, stderr: childStderr, ...exitInfo };
   }
@@ -300,7 +337,7 @@ export class ProcessExecutor {
     processInfo: ProcessInfo,
     nonZeroExitCodeHandling: NonZeroExitCodeHandling,
     nonZeroExitCodeMessageCreator: () => string,
-    logger: Logger = this.logger
+    logger: Logger
   ) {
     const { exitCode } = exitInfo;
 
@@ -325,8 +362,9 @@ export class ProcessExecutor {
   private normalizeOptions(options: ProcessInfoOptions | undefined): Required<ProcessInfoOptions> {
     return {
       cwd: options?.cwd ?? process.cwd(),
-      nonZeroExitCodeHandling: options?.nonZeroExitCodeHandling ?? "printErrorAndThrow",
       env: { ...(options?.env ?? process.env) },
+      nonZeroExitCodeHandling: options?.nonZeroExitCodeHandling ?? "printErrorAndThrow",
+      suppressNotices: !!options?.suppressNotices,
     };
   }
 }
@@ -444,14 +482,29 @@ function noticeHighlightStyled(s: string): string {
   return reset(dim(bold(s)));
 }
 
-class Logger {
-  constructor(private readonly logFunction: LogFunction) {}
+interface Logger {
+  notice: LogFunction;
+  error: LogFunction;
+}
+
+class StylingLogger implements Logger {
+  constructor(private readonly logFunction: LogFunction) {
+    this.notice = this.notice.bind(this);
+    this.error = this.error.bind(this);
+  }
 
   notice(message?: any, ...optionalParams: any[]): void {
     this.logFunction(noticeStyled(message), ...optionalParams);
   }
   error(message?: any, ...optionalParams: any[]): void {
     this.logFunction(red(message), ...optionalParams);
+  }
+
+  withSuppression(suppressNotices: boolean): Logger {
+    if (suppressNotices) {
+      return { notice: () => {}, error: this.error };
+    }
+    return this;
   }
 }
 

--- a/packages/devcmd/src/process/process.test.ts
+++ b/packages/devcmd/src/process/process.test.ts
@@ -1,9 +1,6 @@
 import path from "path";
-import { isString } from "../utils/type_utils";
 import { ProcessExecutor } from ".";
 import { ConsoleLike } from "./ProcessExecutor";
-
-const ansiFormat = `(?:\\x1b\\[\\d+m)`;
 
 describe("ProcessExecutor", () => {
   describe("execInTty()", () => {
@@ -12,10 +9,11 @@ describe("ProcessExecutor", () => {
         const capturingConsole = new CapturingConsole();
         const execInTty = new ProcessExecutor(capturingConsole).execInTty;
         await execInTty({ command: "node", args: ["--version"] });
-        const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines);
-        expect(consoleErrLines).toHaveLength(2);
-        expect(stripAnsiColorSequences(consoleErrLines[0])).toMatch(/^Starting process/);
-        expect(stripAnsiColorSequences(consoleErrLines[1])).toMatch(/^Process "node" exited successfully/);
+        expect(capturingConsole.errorMessages).toHaveLength(2);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[0])).toMatch(/^Starting process/);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[1])).toMatch(
+          /^Process "node" exited successfully/
+        );
       });
 
       test("process that successfully exits works (with no console)", async () => {
@@ -36,9 +34,9 @@ describe("ProcessExecutor", () => {
         const execInTty = new ProcessExecutor(capturingConsole).execInTty;
         const execPromise = execInTty({ command: "node", args: ["-e", "process.exit(2)"] });
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
-        expect(capturingConsole.errorLines).toHaveLength(2);
-        expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+        expect(capturingConsole.errorMessages).toHaveLength(2);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[1])).toMatch(
+          /^Process "node" exited with status code 2/
         );
       });
     });
@@ -63,9 +61,9 @@ describe("ProcessExecutor", () => {
           options: { nonZeroExitCodeHandling: "printNoticeAndReturn" },
         });
         expect(result.exitCode).toBe(2);
-        expect(capturingConsole.errorLines).toHaveLength(2);
-        expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+        expect(capturingConsole.errorMessages).toHaveLength(2);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[1])).toMatch(
+          /^Process "node" exited with status code 2/
         );
       });
     });
@@ -79,7 +77,7 @@ describe("ProcessExecutor", () => {
           args: ["--version"],
           options: { suppressNotices: true },
         });
-        expect(capturingConsole.errorLines).toHaveLength(0);
+        expect(capturingConsole.errorMessages).toHaveLength(0);
       });
 
       test("failing executable prints and throws", async () => {
@@ -92,9 +90,10 @@ describe("ProcessExecutor", () => {
           options: { suppressNotices: true },
         });
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
-        const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines);
-        expect(consoleErrLines).toHaveLength(1);
-        expect(stripAnsiColorSequences(consoleErrLines[0])).toMatch(/^Process "node" exited with status code 2/);
+        expect(capturingConsole.errorMessages).toHaveLength(1);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[0])).toMatch(
+          /^Process "node" exited with status code 2/
+        );
       });
     });
   });
@@ -105,10 +104,11 @@ describe("ProcessExecutor", () => {
         const capturingConsole = new CapturingConsole();
         const execPiped = new ProcessExecutor(capturingConsole).execPiped;
         await execPiped({ command: "node", args: ["--version"] });
-        const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines);
-        expect(consoleErrLines).toHaveLength(2);
-        expect(stripAnsiColorSequences(consoleErrLines[0])).toMatch(/^Starting process/);
-        expect(stripAnsiColorSequences(consoleErrLines[1])).toMatch(/^Process "node" exited successfully/);
+        expect(capturingConsole.errorMessages).toHaveLength(2);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[0])).toMatch(/^Starting process/);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[1])).toMatch(
+          /^Process "node" exited successfully/
+        );
       });
 
       test("process that successfully exits works (with no console)", async () => {
@@ -129,9 +129,9 @@ describe("ProcessExecutor", () => {
         const execPiped = new ProcessExecutor(capturingConsole).execPiped;
         const execPromise = execPiped({ command: "node", args: ["-e", "process.exit(2)"] });
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
-        expect(capturingConsole.errorLines).toHaveLength(2);
-        expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+        expect(capturingConsole.errorMessages).toHaveLength(2);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[1])).toMatch(
+          /^Process "node" exited with status code 2/
         );
       });
     });
@@ -156,11 +156,11 @@ describe("ProcessExecutor", () => {
           options: { nonZeroExitCodeHandling: "printNoticeAndReturn" },
         });
         expect(result.exitCode).toBe(2);
-        expect(capturingConsole.logLines).toHaveLength(1);
-        expect(capturingConsole.logLines[0].message).toBe("still works");
-        expect(capturingConsole.errorLines).toHaveLength(2);
-        expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+        expect(capturingConsole.logMessages).toHaveLength(1);
+        expect(capturingConsole.logMessages[0]).toBe("still works");
+        expect(capturingConsole.errorMessages).toHaveLength(2);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[1])).toMatch(
+          /^Process "node" exited with status code 2/
         );
       });
     });
@@ -174,7 +174,7 @@ describe("ProcessExecutor", () => {
           args: ["--version"],
           options: { suppressNotices: true },
         });
-        expect(capturingConsole.errorLines).toHaveLength(0);
+        expect(capturingConsole.errorMessages).toHaveLength(0);
       });
 
       test("failing executable prints and throws", async () => {
@@ -187,9 +187,10 @@ describe("ProcessExecutor", () => {
           options: { suppressNotices: true },
         });
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
-        const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines);
-        expect(consoleErrLines).toHaveLength(1);
-        expect(stripAnsiColorSequences(consoleErrLines[0])).toMatch(/^Process "node" exited with status code 2/);
+        expect(capturingConsole.errorMessages).toHaveLength(1);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[0])).toMatch(
+          /^Process "node" exited with status code 2/
+        );
       });
     });
 
@@ -203,11 +204,9 @@ describe("ProcessExecutor", () => {
         args: ["-e", `console.log('${outputPrefix}' + process.cwd());`],
         options: { cwd: childProcessCwd },
       });
-      const outputLines = capturingConsole.logLines.filter(
-        (l) => isString(l.message) && l.message.startsWith(outputPrefix)
-      );
+      const outputLines = capturingConsole.logMessages.filter((l) => l.startsWith(outputPrefix));
       expect(outputLines).toHaveLength(1);
-      expect(outputLines[0].message).toEqual(`${outputPrefix}${childProcessCwd}`);
+      expect(outputLines[0]).toEqual(`${outputPrefix}${childProcessCwd}`);
     });
   });
 
@@ -220,9 +219,7 @@ describe("ProcessExecutor", () => {
           node: { command: "node", args: ["--version"] },
           node2: { command: "node", args: ["-e", "console.log('The other node process');"] },
         });
-        const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines).map(
-          stripAnsiColorSequences
-        );
+        const consoleErrLines = capturingConsole.errorMessages.map(stripAnsiColorSequences);
         expect(consoleErrLines).toHaveLength(6);
         expect(consoleErrLines.filter((s) => s.includes("Starting process"))).toHaveLength(2);
         expect(consoleErrLines.filter((s) => s.includes(`exited successfully`))).toHaveLength(2);
@@ -261,13 +258,10 @@ describe("ProcessExecutor", () => {
           node2: { command: "node", args: ["-e", "console.log('The other node process');"] },
         });
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
-        const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines).map(
-          stripAnsiColorSequences
-        );
-        expect(consoleErrLines).toHaveLength(6);
-        const errorLine = consoleErrLines.filter((l) =>
-          l.startsWith(`<node> Process "node" exited with status code 2`)
-        );
+        expect(capturingConsole.errorMessages).toHaveLength(6);
+        const errorLine = capturingConsole.errorMessages
+          .map(stripAnsiColorSequences)
+          .filter((l) => l.startsWith(`<node> Process "node" exited with status code 2`));
         expect(errorLine).toHaveLength(1);
       });
 
@@ -296,16 +290,10 @@ describe("ProcessExecutor", () => {
           node2: { command: "node", args: ["-e", "console.log('The other node process');"] },
         });
         expect(results.node.exitCode).toBe(2);
-        expect(capturingConsole.errorLines).toHaveLength(6);
-        const errorLine = capturingConsole.errorLines.filter(
-          (l) => isString(l.message) && l.message.includes("exited with status code")
-        );
+        expect(capturingConsole.errorMessages).toHaveLength(6);
+        const errorLine = capturingConsole.errorMessages.filter((l) => l.includes("exited with status code"));
         expect(errorLine).toHaveLength(1);
-        expect(errorLine[0].message).toMatch(
-          new RegExp(
-            `^${ansiFormat}?<node> ${ansiFormat}?${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`
-          )
-        );
+        expect(stripAnsiColorSequences(errorLine[0])).toMatch(/^<node> Process "node" exited with status code 2/);
       });
 
       test("multiple failing processes prints and returns without throwing", async () => {
@@ -325,10 +313,8 @@ describe("ProcessExecutor", () => {
         ]);
         expect(results[0].exitCode).toBe(2);
         expect(results[1].exitCode).toBe(5);
-        expect(capturingConsole.errorLines).toHaveLength(6);
-        const errorLine = capturingConsole.errorLines.filter(
-          (l) => isString(l.message) && l.message.includes("exited with status code")
-        );
+        expect(capturingConsole.errorMessages).toHaveLength(6);
+        const errorLine = capturingConsole.errorMessages.filter((l) => l.includes("exited with status code"));
         expect(errorLine).toHaveLength(2);
       });
     });
@@ -344,10 +330,7 @@ describe("ProcessExecutor", () => {
           },
           { suppressNotices: true }
         );
-        const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines).map(
-          stripAnsiColorSequences
-        );
-        expect(consoleErrLines).toHaveLength(0);
+        expect(capturingConsole.errorMessages).toHaveLength(0);
       });
     });
     describe("with option suppressNotices=true on single process", () => {
@@ -358,11 +341,10 @@ describe("ProcessExecutor", () => {
           node1: { command: "node", args: ["--version"], options: { suppressNotices: true } },
           node2: { command: "node", args: ["-e", "console.log('The other node process');"] },
         });
-        const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines).map(
-          stripAnsiColorSequences
-        );
-        expect(consoleErrLines).toHaveLength(4);
-        expect(consoleErrLines.filter((s) => s.includes("node1"))).toHaveLength(0);
+        expect(capturingConsole.errorMessages).toHaveLength(4);
+        expect(
+          capturingConsole.errorMessages.map(stripAnsiColorSequences).filter((s) => s.includes("node1"))
+        ).toHaveLength(0);
       });
     });
   });
@@ -375,10 +357,11 @@ describe("ProcessExecutor", () => {
         const { stdout, stderr } = await execToString({ command: "node", args: ["--version"] });
         expect(stderr).toBe("");
         expect(stdout).toMatch(/v\d+\.\d+\.\d+/);
-        const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines);
-        expect(consoleErrLines).toHaveLength(2);
-        expect(stripAnsiColorSequences(consoleErrLines[0])).toMatch(/^Starting process/);
-        expect(stripAnsiColorSequences(consoleErrLines[1])).toMatch(/^Process "node" exited successfully/);
+        expect(capturingConsole.errorMessages).toHaveLength(2);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[0])).toMatch(/^Starting process/);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[1])).toMatch(
+          /^Process "node" exited successfully/
+        );
       });
 
       test("process that successfully exits works (with no console)", async () => {
@@ -401,9 +384,9 @@ describe("ProcessExecutor", () => {
         const execToString = new ProcessExecutor(capturingConsole).execToString;
         const execPromise = execToString({ command: "node", args: ["-e", "process.exit(2)"] });
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
-        expect(capturingConsole.errorLines).toHaveLength(2);
-        expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+        expect(capturingConsole.errorMessages).toHaveLength(2);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[1])).toMatch(
+          /^Process "node" exited with status code 2/
         );
       });
     });
@@ -429,9 +412,9 @@ describe("ProcessExecutor", () => {
         });
         expect(result.exitCode).toBe(2);
         expect(result.stdout).toBe("still works\n");
-        expect(capturingConsole.errorLines).toHaveLength(2);
-        expect(capturingConsole.errorLines[1].message).toMatch(
-          new RegExp(`^${ansiFormat}?Process "${ansiFormat}?node${ansiFormat}?" exited with status code 2`)
+        expect(capturingConsole.errorMessages).toHaveLength(2);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[1])).toMatch(
+          /^Process "node" exited with status code 2/
         );
       });
     });
@@ -447,7 +430,7 @@ describe("ProcessExecutor", () => {
         });
         expect(stderr).toBe("");
         expect(stdout).toMatch(/v\d+\.\d+\.\d+/);
-        expect(capturingConsole.errorLines).toHaveLength(0);
+        expect(capturingConsole.errorMessages).toHaveLength(0);
       });
 
       test("failing executable prints and throws", async () => {
@@ -460,9 +443,10 @@ describe("ProcessExecutor", () => {
           options: { suppressNotices: true },
         });
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
-        const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines);
-        expect(consoleErrLines).toHaveLength(1);
-        expect(stripAnsiColorSequences(consoleErrLines[0])).toMatch(/^Process "node" exited with status code 2/);
+        expect(capturingConsole.errorMessages).toHaveLength(1);
+        expect(stripAnsiColorSequences(capturingConsole.errorMessages[0])).toMatch(
+          /^Process "node" exited with status code 2/
+        );
       });
     });
 
@@ -493,26 +477,35 @@ interface LogLine {
 }
 
 class CapturingConsole implements ConsoleLike {
-  private readonly _logLines: LogLine[] = [];
-  private readonly _errorLines: LogLine[] = [];
-  get logLines(): readonly LogLine[] {
-    return this._logLines;
+  private readonly _rawLogLines: LogLine[] = [];
+  private readonly _logMessages: string[] = [];
+  private readonly _rawErrorLines: LogLine[] = [];
+  private readonly _errorMessages: string[] = [];
+
+  get rawLogLines(): readonly LogLine[] {
+    return this._rawLogLines;
   }
-  get errorLines(): readonly LogLine[] {
-    return this._errorLines;
-  }
-  log(message?: any, ...optionalParams: any[]): void {
-    this._logLines.push({ message, optionalParams });
-  }
-  error(message?: any, ...optionalParams: any[]): void {
-    this._errorLines.push({ message, optionalParams });
+  get rawErrorLines(): readonly LogLine[] {
+    return this._rawErrorLines;
   }
 
-  static extractMessageStrings(logLines: readonly LogLine[]): string[] {
-    return logLines.map(({ message }) => message?.toString() ?? "");
+  get logMessages(): readonly string[] {
+    return this._logMessages;
+  }
+  get errorMessages(): readonly string[] {
+    return this._errorMessages;
+  }
+
+  log(message?: any, ...optionalParams: any[]): void {
+    this._rawLogLines.push({ message, optionalParams });
+    this._logMessages.push((message ?? "").toString());
+  }
+  error(message?: any, ...optionalParams: any[]): void {
+    this._rawErrorLines.push({ message, optionalParams });
+    this._errorMessages.push((message ?? "").toString());
   }
 }
 
 function stripAnsiColorSequences(s: string): string {
-  return s.replace(new RegExp(ansiFormat, "g"), "");
+  return s.replace(/(?:\x1b\[\d+m)/g, "");
 }

--- a/packages/devcmd/src/process/process.test.ts
+++ b/packages/devcmd/src/process/process.test.ts
@@ -218,7 +218,7 @@ describe("ProcessExecutor", () => {
         const execPipedParallel = new ProcessExecutor(capturingConsole).execPipedParallel;
         await execPipedParallel({
           node: { command: "node", args: ["--version"] },
-          npm: { command: withCmdOnWin("npm"), args: ["--version"] },
+          node2: { command: "node", args: ["-e", "console.log('The other node process');"] },
         });
         const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines).map(
           stripAnsiColorSequences
@@ -232,7 +232,7 @@ describe("ProcessExecutor", () => {
         const execPipedParallel = new ProcessExecutor(undefined as any).execPipedParallel;
         await execPipedParallel({
           node: { command: "node", args: ["--version"] },
-          npm: { command: withCmdOnWin("npm"), args: ["--version"] },
+          node2: { command: "node", args: ["-e", "console.log('The other node process');"] },
         });
       });
 
@@ -240,7 +240,7 @@ describe("ProcessExecutor", () => {
         const execPipedParallel = new ProcessExecutor(nullConsole).execPipedParallel;
         await execPipedParallel({
           1: { command: "node", args: ["--version"] },
-          2: { command: withCmdOnWin("npm"), args: ["--version"] },
+          2: { command: "node", args: ["-e", "console.log('The other node process');"] },
         });
       });
 
@@ -248,7 +248,7 @@ describe("ProcessExecutor", () => {
         const execPipedParallel = new ProcessExecutor(nullConsole).execPipedParallel;
         await execPipedParallel([
           { command: "node", args: ["--version"] },
-          { command: withCmdOnWin("npm"), args: ["--version"] },
+          { command: "node", args: ["-e", "console.log('The other node process');"] },
         ]);
       });
 
@@ -258,7 +258,7 @@ describe("ProcessExecutor", () => {
         const execPipedParallel = new ProcessExecutor(capturingConsole).execPipedParallel;
         const execPromise = execPipedParallel({
           node: { command: "node", args: ["-e", "process.exit(2)"] },
-          npm: { command: withCmdOnWin("npm"), args: ["--version"] },
+          node2: { command: "node", args: ["-e", "console.log('The other node process');"] },
         });
         await expect(execPromise).rejects.toThrowError("exited with status code 2");
         const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines).map(
@@ -293,7 +293,7 @@ describe("ProcessExecutor", () => {
             args: ["-e", "process.exit(2)"],
             options: { nonZeroExitCodeHandling: "printNoticeAndReturn" },
           },
-          npm: { command: withCmdOnWin("npm"), args: ["--version"] },
+          node2: { command: "node", args: ["-e", "console.log('The other node process');"] },
         });
         expect(results.node.exitCode).toBe(2);
         expect(capturingConsole.errorLines).toHaveLength(6);
@@ -340,7 +340,7 @@ describe("ProcessExecutor", () => {
         await execPipedParallel(
           {
             node: { command: "node", args: ["--version"] },
-            npm: { command: withCmdOnWin("npm"), args: ["--version"] },
+            node2: { command: "node", args: ["-e", "console.log('The other node process');"] },
           },
           { suppressNotices: true }
         );
@@ -355,14 +355,14 @@ describe("ProcessExecutor", () => {
         const capturingConsole = new CapturingConsole();
         const execPipedParallel = new ProcessExecutor(capturingConsole).execPipedParallel;
         await execPipedParallel({
-          node: { command: "node", args: ["--version"], options: { suppressNotices: true } },
-          npm: { command: withCmdOnWin("npm"), args: ["--version"] },
+          node1: { command: "node", args: ["--version"], options: { suppressNotices: true } },
+          node2: { command: "node", args: ["-e", "console.log('The other node process');"] },
         });
         const consoleErrLines = CapturingConsole.extractMessageStrings(capturingConsole.errorLines).map(
           stripAnsiColorSequences
         );
         expect(consoleErrLines).toHaveLength(4);
-        expect(consoleErrLines.filter((s) => s.includes("node"))).toHaveLength(0);
+        expect(consoleErrLines.filter((s) => s.includes("node1"))).toHaveLength(0);
       });
     });
   });
@@ -511,14 +511,6 @@ class CapturingConsole implements ConsoleLike {
   static extractMessageStrings(logLines: readonly LogLine[]): string[] {
     return logLines.map(({ message }) => message?.toString() ?? "");
   }
-}
-
-function isWindows(): boolean {
-  return process.platform === "win32";
-}
-
-function withCmdOnWin(baseCmd: string): string {
-  return isWindows() ? `${baseCmd}.cmd` : baseCmd;
 }
 
 function stripAnsiColorSequences(s: string): string {


### PR DESCRIPTION
As discussed in #47, it's sometimes convenient to use DevCmd's exec* methods without having them output any of their notices ("Starting process..." and "Process xy exited...").

This PR adds this optional behavior to all exec* methods, including unit tests.

~This PR is based on #48 and must be merged after it.~ Rebased onto new main since previous PR is now merged.