### PR TITLE
Fix checkPackageAvailable function for Windows

### DIFF
--- a/packages/devcmd/src/utils/npm_utils.ts
+++ b/packages/devcmd/src/utils/npm_utils.ts
@@ -1,9 +1,10 @@
 import { spawn } from "child_process";
+import { withCmdOnWin } from "..";
 
 export async function checkPackageAvailable(packageName: string, directory: string): Promise<boolean> {
   return new Promise<boolean>((res) => {
-    // npm ls <package_name> only exits with status code 0 when <package_name> is available
-    const childProcess = spawn("npm", ["ls", packageName], { cwd: directory });
+    // `npm ls <package_name>` only exits with status code 0 when <package_name> is available
+    const childProcess = spawn(withCmdOnWin("npm"), ["ls", packageName], { cwd: directory });
 
     childProcess.on("error", (): void => res(false));
     childProcess.on("close", (code: number): void => res(code === 0));


### PR DESCRIPTION
Here's a hotfix for an issue I just noticed while trying to use the latest release on my Windows PC.

This isn't the first time that differences between *nix and Windows cause issues for us. We should think about how we can maybe add (integration) test coverage for Windows in our Github builds :(

/cc @lieberlois (no blame here, I also didn't catch this while reviewing and testing, just thought you'd be interested)